### PR TITLE
Add new Google Calendar functionality

### DIFF
--- a/spring-social-google/src/main/java/org/springframework/social/google/api/Google.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/Google.java
@@ -20,11 +20,12 @@ import org.springframework.social.google.api.drive.DriveOperations;
 import org.springframework.social.google.api.impl.GoogleTemplate;
 import org.springframework.social.google.api.plus.PlusOperations;
 import org.springframework.social.google.api.tasks.TaskOperations;
+import org.springframework.social.google.api.calendar.CalendarOperations;
 
 /**
  * Interface specifying a basic set of operations for interacting with Google
  * APIs. Implemented by {@link GoogleTemplate}.
- * 
+ *
  * @author Gabriel Axel
  */
 public interface Google extends ApiBinding {
@@ -32,7 +33,7 @@ public interface Google extends ApiBinding {
 	/**
 	 * Retrieves {@link PlusOperations}, used for interacting with Google+ API.
 	 * Some methods require OAuth2 scope https://www.googleapis.com/auth/plus.me
-	 * 
+	 *
 	 * @return {@link PlusOperations} for the authenticated user if
 	 *         authenticated
 	 */
@@ -42,7 +43,7 @@ public interface Google extends ApiBinding {
 	 * Retrieves {@link TaskOperations}, used for interacting with Google Tasks
 	 * API. Requires OAuth scope https://www.googleapis.com/auth/tasks or
 	 * https://www.googleapis.com/auth/tasks.readonly
-	 * 
+	 *
 	 * @return {@link TaskOperations} for the authenticated user
 	 */
 	TaskOperations taskOperations();
@@ -60,17 +61,29 @@ public interface Google extends ApiBinding {
 	 * See <a
 	 * href="https://developers.google.com/drive/scopes">https://developers
 	 * .google.com/drive/scopes</a> for details about the different scopes
-	 * 
+	 *
 	 * @return {@link DriveOperations} for the authenticated user
 	 */
 	DriveOperations driveOperations();
 
 	/**
+	 * Retrieves {@link CalendarOperations}, used for interacting with Google Calendar API.
+	 * Some methods require OAuth2 scope from the following:
+	 * <ul>
+	 * <li>https://www.googleapis.com/auth/calendar.readonly</li>
+	 * <li>https://www.googleapis.com/auth/calendar</li>
+	 * </ul>
+	 *
+	 * @return {@link CalendarOperations} for the authenticated user if authenticated
+	 */
+	CalendarOperations calendarOperations();
+
+	/**
 	 * Returns the access token, allowing interoperability with other libraries
-	 * 
+	 *
 	 * @see <a href="http://code.google.com/p/google-api-java-client/">Google
 	 *      APIs Client Library for Java</a>
-	 * 
+	 *
 	 * @return The OAuth2 access token
 	 */
 	String getAccessToken();

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/AttendeeStatus.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/AttendeeStatus.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.calendar.impl.AttendeeStatusDeserializer;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Enumeration representing an attendee's response status.
+ * 
+ * @author Martin Wink
+ */
+@JsonSerialize(using=ApiEnumSerializer.class)
+@JsonDeserialize(using=AttendeeStatusDeserializer.class)
+public enum AttendeeStatus {
+	/**
+	 * "needsAction" - The attendee has not responded to the invitation.
+	 */
+	NEEDS_ACTION,
+	
+	/**
+	 * "declined" - The attendee has declined the invitation.
+	 */
+	DECLINED,
+	
+	/**
+	 * "tentative" - The attendee has tentatively accepted the invitation.
+	 */
+	TENTATIVE,
+	
+	/**
+	 * "accepted" - The attendee has accepted the invitation.
+	 */
+	ACCEPTED
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Calendar.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Calendar.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import java.util.List;
+import java.util.TimeZone;
+
+import org.springframework.social.google.api.ApiEntity;
+import org.springframework.social.google.api.calendar.impl.TimeZoneDeserializer;
+import org.springframework.social.google.api.calendar.impl.TimeZoneSerializer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Model class representing a calendar within Google Calendar.
+ * <p>See the reference documentation at
+ * <a href="https://developers.google.com/google-apps/calendar/v3/reference/calendarList#resource">
+ * https://developers.google.com/google-apps/calendar/v3/reference/calendarList#resource</a>.
+ * </p>
+ * @author Martin Wink
+ */
+public class Calendar extends ApiEntity {
+
+	/**
+	 * Details of event reminders.
+	 */
+	public static class EventReminder {
+		private NotificationMethod method;
+		private int minutes;
+
+		/**
+		 * The notification method used by the reminder.
+		 * @return the value.
+		 */
+		public NotificationMethod getMethod() {
+			return method;
+		}
+		
+		/**
+		 * The number of minutes before the start of the event when the reminder should
+		 * trigger.
+		 * @return the value.
+		 */
+		public int getMinutes() {
+			return minutes;
+		}
+	}
+
+	/**
+	 * Details of an individual notification.
+	 */
+	public static class Notification {
+		private NotificationType type;
+		private NotificationMethod method;
+
+		/**
+		 * The type of notification.
+		 * @return the value.
+		 */
+		public NotificationType getType() {
+			return type;
+		}
+		
+		/**
+		 * The method used to deliver the notification.
+		 * @return the value.
+		 */
+		public NotificationMethod getMethod() {
+			return method;
+		}
+	}
+
+	/**
+	 * Details of notifications.
+	 */
+	public static class NotificationSettings {
+		private List<Notification> notifications;
+
+		/**
+		 * The list of notifications set for this calendar.
+		 * @return the value.
+		 */
+		public List<Notification> getNotifications() {
+			return notifications;
+		}
+	}
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String summary;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String description;
+	
+	@JsonInclude(value = Include.NON_NULL)
+	private String location;
+    
+	@JsonInclude(value = Include.NON_NULL)
+	@JsonDeserialize(using = TimeZoneDeserializer.class)
+	@JsonSerialize(using = TimeZoneSerializer.class)
+	private TimeZone timeZone;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String summaryOverride;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String colorId;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String backgroundColor;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String foregroundColor;
+
+	@JsonInclude(value = Include.NON_DEFAULT)
+	private boolean hidden;
+
+	@JsonInclude(value = Include.NON_DEFAULT)
+	private boolean selected;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private PermissionRole accessRole;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private List<EventReminder> defaultReminders;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private NotificationSettings notificationSettings;
+
+	@JsonInclude(value = Include.NON_DEFAULT)
+	private boolean primary;
+
+	@JsonInclude(value = Include.NON_DEFAULT)
+	private boolean deleted;
+
+	/**
+	 * Constructor protected so instances must be retrieved from Google Calendar.
+	 */
+	protected Calendar() {
+		super();
+	}
+
+	/**
+	 * The title of this calendar.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getSummary() {
+		return summary;
+	}
+	
+	/**
+	 * The description of this calendar.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getDescription() {
+		return description;
+	}
+	
+	/**
+	 * The geographic location of this calendar as free-form text.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getLocation() {
+		return location;
+	}
+
+	/**
+	 * The time zone of this calendar.
+	 * @return the value or {@code null} if none.
+	 */
+	public TimeZone getTimeZone() {
+		return timeZone;
+	}
+	
+	/**
+	 * The overriding summary that the authenticated user has set for this calendar.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getSummaryOverride() {
+		return summaryOverride;
+	}
+	
+	/**
+	 * The colour of this calendar. 
+	 * @return the value or {@code null} if none.
+	 */
+	public String getColorId() {
+		return colorId;
+	}
+	
+	/**
+	 * The background colour of this calendar in hexadecimal format "#rrggbb".
+	 * @return the value or {@code null} if none.
+	 */
+	public String getBackgroundColor() {
+		return backgroundColor;
+	}
+	
+	/**
+	 * The foreground colour of this calendar in hexadecimal format "#rrggbb".
+	 * @return the value or {@code null} if none.
+	 */
+	public String getForegroundColor() {
+		return foregroundColor;
+	}
+
+	/**
+	 * Whether this calendar has been hidden from the list.
+	 * @return the value.
+	 */
+	public boolean isHidden() {
+		return hidden;
+	}
+	
+	/**
+	 * Whether this calendar's content is displayed in the calendar UI.
+	 * @return the value.
+	 */
+	public boolean isSelected() {
+		return selected;
+	}
+	
+	/**
+	 * The effective access role that the authenticated user has on this calendar.
+	 * @return the value or {@code null} if none.
+	 */
+	public PermissionRole getAccessRole() {
+		return accessRole;
+	}
+	
+	/**
+	 * The default reminders that the authenticated user has for this calendar.
+	 * @return the value or {@code null} if none.
+	 */
+	public List<EventReminder> getDefaultReminders() {
+		return defaultReminders;
+	}
+	
+	/**
+	 * The notifications that the authenticated user is receiving for this calendar.
+	 * @return the value or {@code null} if none.
+	 */
+	public NotificationSettings getNotificationSettings() {
+		return notificationSettings;
+	}
+	
+	/**
+	 * Whether this calendar is the primary calendar of the authenticated user.
+	 * @return the value.
+	 */
+	public boolean isPrimary() {
+		return primary;
+	}
+	
+	/**
+	 * Whether this calendar has been deleted from the calendar list.
+	 * @return the value.
+	 */
+	public boolean isDeleted() {
+		return deleted;
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/CalendarListQueryBuilder.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/CalendarListQueryBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.query.ApiQueryBuilder;
+
+/**
+ * Constructs queries for listing the accessible calendars, following the builder pattern.
+ * The {@link #getPage()} method returns a {@link CalendarPage} containing
+ * {@link Calendar} instances.
+ * <p>See the reference documentation at
+ * <a href="http://developers.google.com/google-apps/calendar/v3/reference/calendarList/list">
+ * http://developers.google.com/google-apps/calendar/v3/reference/calendarList/list</a>
+ * for details of the parameters.
+ * </p>
+ * 
+ * @author Martin Wink
+ */
+public interface CalendarListQueryBuilder extends ApiQueryBuilder<CalendarListQueryBuilder, CalendarPage> {
+	/**
+	 * The minimum access role for the user in the returned entries. Optional.
+	 * The default is no restriction. 
+	 * @param minAccessRole the minimum access role for the user in the returned entries.
+	 * @return this {@code CalendarListQueryBuilder}, for refining the query.
+	 */
+	CalendarListQueryBuilder minAccessRole(PermissionRole minAccessRole);
+	
+	/**
+	 * Whether to include deleted calendar list entries in the result. Optional.
+	 * The default is false.
+	 * @param showDeleted whether to include deleted calendar list entries in the result.
+	 * @return this {@code CalendarListQueryBuilder}, for refining the query.
+	 */
+	CalendarListQueryBuilder showDeleted(boolean showDeleted);
+	
+	/**
+	 * Whether to show hidden entries. Optional. The default is false.
+	 * @param showHidden whether to show hidden entries.
+	 * @return this {@code CalendarListQueryBuilder}, for refining the query.
+	 */
+	CalendarListQueryBuilder showHidden(boolean showHidden);
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/CalendarOperations.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/CalendarOperations.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+/**
+ * Interface defining operations for integrating with Google Calendar.
+ * <p>See the reference documentation at
+ * <a href="http://developers.google.com/google-apps/calendar/v3/reference/">
+ * http://developers.google.com/google-apps/calendar/v3/reference/</a>.</p>
+ * <p>Requires one of the following OAuth scope(s):
+ * <ul>
+ * <li>https://www.googleapis.com/auth/calendar.readonly</li>
+ * <li>https://www.googleapis.com/auth/calendar</li>
+ * </ul>
+ * See
+ * <a href="http://developers.google.com/google-apps/calendar/auth">
+ * http://developers.google.com/google-apps/calendar/auth</a>
+ * for details about the different scopes.</p>
+ * 
+ * @author Martin Wink
+ */
+public interface CalendarOperations {
+	/**
+	 * The identifier for the user's primary calendar.
+	 */
+	public static final String PRIMARY_CALENDAR_ID = "primary";
+	
+	/**
+	 * Create a builder pattern object for refining a query that lists the calendars
+	 * that are accessible to the authenticated user.
+	 * @return a query builder for listing calendars.
+	 */
+	CalendarListQueryBuilder calendarListQuery();
+	
+	/** Fetch a calendar from the user's calendar list.
+	 * @param calendarId the calendar's identifier. The special identifier "primary"
+	 * ({@link #PRIMARY_CALENDAR_ID}) may be used.
+	 * @return the calendar.
+	 */
+	Calendar getCalendar(String calendarId);
+	
+	/**
+	 * Create a builder pattern object for refining a query that lists the events that
+	 * are accessible to the authenticated user.
+	 * @param calendarId the calendar's identifier. The special identifier "primary"
+	 * ({@link #PRIMARY_CALENDAR_ID}) may be used.
+	 * @return a query builder for listing events.
+	 */
+	EventListQueryBuilder eventListQuery(String calendarId);
+	
+	/**
+	 * Fetch an event from the specified calendar.
+	 * @param calendarId the calendar's identifier. The special identifier "primary"
+	 * ({@link #PRIMARY_CALENDAR_ID}) may be used.
+	 * @param eventId the event's identifier.
+	 * @return the event.
+	 */
+	Event getEvent(String calendarId, String eventId);
+	
+	/**
+	 * Create a new event in the specified calendar, based on the specification text.
+	 * @param calendarId the calendar's identifier. The special identifier "primary"
+	 * ({@link #PRIMARY_CALENDAR_ID}) may be used.
+	 * @param specification text describing the event to be created.
+	 * @param sendNotifications whether to send notifications about the creation of the event.
+	 * @return the new event.
+	 */
+	Event quickAddEvent(String calendarId, String specification, boolean sendNotifications);
+	
+	/**
+	 * Delete an existing event.
+	 * @param calendarId the identifier of the calendar containing the event. The special
+	 * identifier "primary" ({@link #PRIMARY_CALENDAR_ID}) may be used.
+	 * @param eventId the event's identifier.
+	 * @param sendNotifications whether to send notifications about the deletion of the event.
+	 */
+	void deleteEvent(String calendarId, String eventId, boolean sendNotifications);
+	
+	/**
+	 * Update an existing event.
+	 * @param calendarId The identifier of the calendar containing the event.
+	 * The special identifier "primary" ({@link #PRIMARY_CALENDAR_ID}) may be used.
+	 * @param event The event to update.
+	 * @param sendNotifications Whether to send notifications about the update to the event.
+	 */
+	void updateEvent(String calendarId, Event event, boolean sendNotifications);
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/CalendarPage.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/CalendarPage.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.query.ApiPage;
+
+/**
+ * A specialized {@link ApiPage} containing {@link Calendar} instances.
+ * 
+ * @author Martin Wink
+ */
+public class CalendarPage extends ApiPage<Calendar> {
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/DeleteEventBuilder.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/DeleteEventBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+
+/**
+ * Interface for constructing queries for deleting an event from a calendar, following
+ * the builder pattern.
+ * <p>(Currently only used internally within {@link CalendarOperations#deleteEvent}.)</p>
+ * 
+ * @author Martin Wink
+ */
+public interface DeleteEventBuilder extends UriQueryBuilder<DeleteEventBuilder, Object> {
+	DeleteEventBuilder sendNotifications(boolean sendNotifications);
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/DisplayMode.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/DisplayMode.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.calendar.impl.DisplayModeDeserializer;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Enumeration representing a gadget's display mode.
+ * 
+ * @author Martin Wink
+ */
+@JsonSerialize(using=ApiEnumSerializer.class)
+@JsonDeserialize(using=DisplayModeDeserializer.class)
+public enum DisplayMode {
+	/**
+	 * "icon" - The gadget displays next to the event's title in the calendar view.
+	 */
+	ICON,
+	
+	/**
+	 * "chip" - The gadget displays when the event is clicked.
+	 */
+	CHIP
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Event.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Event.java
@@ -1,0 +1,1019 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.springframework.social.google.api.ApiEntity;
+import org.springframework.social.google.api.calendar.impl.DateTimeDeserializer;
+import org.springframework.social.google.api.calendar.impl.DateTimeSerializer;
+import org.springframework.social.google.api.calendar.impl.TimeZoneDeserializer;
+import org.springframework.social.google.api.calendar.impl.TimeZoneSerializer;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Model class representing an event within Google Calendar.
+ * <p>See the reference documentation at
+ * <a href="https://developers.google.com/google-apps/calendar/v3/reference/events#resource">
+ * https://developers.google.com/google-apps/calendar/v3/reference/events#resource</a>.
+ * </p>
+ * 
+ * @author Martin Wink
+ */
+public class Event extends ApiEntity {
+
+	/**
+	 * Information about the creator of an event.
+	 */
+	public static class Creator {
+		@JsonInclude(value = Include.NON_NULL)
+		private String id;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String email;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String displayName;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Boolean self;
+
+		/**
+		 * The creator's profile ID, if available.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getId() {
+			return id;
+		}
+
+		/**
+		 * The creator's email address, if available.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getEmail() {
+			return email;
+		}
+		
+		/**
+		 * The creator's name, if available.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getDisplayName() {
+			return displayName;
+		}
+
+		/**
+		 * Whether the creator corresponds to the calendar on which this copy of
+		 * the event appears.
+		 * @return the value or {@code null} if none.
+		 */
+		public Boolean isSelf() {
+			return self;
+		}
+	}
+
+	/**
+	 * Information about an event's organizer.
+	 */
+	public static class Organizer {
+		@JsonInclude(value = Include.NON_NULL)
+		private String id;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String email;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String displayName;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Boolean self;
+
+		/**
+		 * The organizer's profile ID, if available.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getId() {
+			return id;
+		}
+
+		/**
+		 * The organizer's email address, if available.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getEmail() {
+			return email;
+		}
+		
+		/**
+		 * The organizer's name, if available.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getDisplayName() {
+			return displayName;
+		}
+		
+		/**
+		 * Whether the organizer corresponds to the calendar on which this copy
+		 * of the event appears.
+		 * @return the value or {@code null} if none.
+		 */
+		public Boolean isSelf() {
+			return self;
+		}
+	}
+	
+	/**
+	 * Details of the start or end of an event.
+	 * <p>Only a {@link #date} or a {@link #dateTime} may be specified.</p>
+	 */
+	public static class DateTimeTimezone {
+		@JsonInclude(value = Include.NON_NULL)
+		@JsonFormat(shape=STRING, pattern="yyyy-MM-dd", timezone="UTC")
+		private Date date;
+
+		@JsonInclude(value = Include.NON_NULL)
+		@JsonDeserialize(using = DateTimeDeserializer.class)
+		@JsonSerialize(using = DateTimeSerializer.class)
+		private Date dateTime;
+
+		@JsonInclude(value = Include.NON_NULL)
+		@JsonDeserialize(using = TimeZoneDeserializer.class)
+		@JsonSerialize(using = TimeZoneSerializer.class)
+		private TimeZone timeZone;
+
+		/**
+		 * The date, if this is an all-day event.
+		 * The time should be midnight on the given date.
+		 * @return the value or {@code null} if none.
+		 */
+		public Date getDate() {
+			return date;
+		}
+		
+		/**
+		 * Set the date to make this an all-day event.
+		 * For consistency, if a non {@code null} value is set, making this an all-day
+		 * event, the time property must be set to {@code null}. 
+		 * @param date the new value or {@code null} if none.
+		 * @return this {@link DateTimeTimezone}, for chaining.
+		 */
+		public DateTimeTimezone setDate(Date date) {
+			this.date = date;
+			return this;
+		}
+
+		/**
+		 * The time, if this is not an all-day event.
+		 * @return the value or {@code null} if none.
+		 */
+		public Date getDateTime() {
+			return dateTime;
+		}
+		
+		/**
+		 * Set the time, to make this not an all-day event.
+		 * For consistency, if a non {@code null} value is set, this cannot also be an
+		 * all-day event, so the date property must be set to {@code null}.
+		 * @param dateTime the new value or {@code null} if none.
+		 * @return this {@link DateTimeTimezone}, for chaining.
+		 */
+		public DateTimeTimezone setDateTime(Date dateTime) {
+			this.dateTime = dateTime;
+			return this;
+		}
+
+		/**
+		 * The time zone in which the time is specified (e.g. "Europe/Zurich").
+		 * The time zone is required for recurring events.
+		 * @return the value or {@code null} if none.
+		 */
+		public TimeZone getTimeZone() {
+			return timeZone;
+		}
+
+		/**
+		 * Set the time zone in which the time is specified (e.g. "Europe/Zurich").
+		 * The time zone is required for recurring events.
+		 * @param date the new value or {@code null} if none.
+		 * @return this {@link DateTimeTimezone}, for chaining.
+		 */
+		public DateTimeTimezone setTimeZone(TimeZone timeZone) {
+			this.timeZone = timeZone;
+			return this;
+		}
+	}
+	
+	/**
+	 * Details of an attendee of an event.
+	 */
+	public static class Attendee {
+		@JsonInclude(value = Include.NON_NULL)
+		private String id;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String email;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String displayName;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Boolean organizer;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Boolean self;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Boolean resource;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Boolean optional;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private AttendeeStatus responseStatus;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String comment;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Integer additionalGuests;
+	
+		/**
+		 * The attendee's Profile ID, if available.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getId() {
+			return id;
+		}
+		
+		/**
+		 * The attendee's email address, if available.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getEmail() {
+			return email;
+		}
+		
+		/**
+		 * The attendee's name, if available.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getDisplayName() {
+			return displayName;
+		}
+		
+		/**
+		 * Whether the attendee is the organizer of the event.
+		 * @return the value or {@code null} if none.
+		 */
+		public Boolean isOrganizer() {
+			return organizer;
+		}
+		
+		/**
+		 * Whether this entry represents the calendar on which this copy of the
+		 * event appears.
+		 * @return the value or {@code null} if none.
+		 */
+		public Boolean isSelf() {
+			return self;
+		}
+		
+		/**
+		 * Whether the attendee is a resource.
+		 * @return the value or {@code null} if none.
+		 */
+		public Boolean isResource() {
+			return resource;
+		}
+		
+		/**
+		 * Whether this is an optional attendee.
+		 * @return the value or {@code null} if none.
+		 */
+		public Boolean isOptional() {
+			return optional;
+		}
+		
+		/**
+		 * The attendee's response status.
+		 * @return the value or {@code null} if none.
+		 */
+		public AttendeeStatus getResponseStatus() {
+			return responseStatus;
+		}
+		
+		/**
+		 * The attendee's response comment.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getComment() {
+			return comment;
+		}
+		
+		/**
+		 * The number of additional guests.
+		 * @return the value or {@code null} if none.
+		 */
+		public Integer getAdditionalGuests() {
+			return additionalGuests;
+		}
+	}
+	
+	/**
+	 * Extended properties of an event.
+	 */
+	public static class ExtendedProperties {
+		@JsonInclude(value = Include.NON_NULL)
+		@JsonProperty("private")
+		private Map<String, String> privateProperties;
+
+		@JsonInclude(value = Include.NON_NULL)
+		@JsonProperty("shared")
+		private Map<String, String> sharedProperties;
+		
+		/**
+		 * Properties that are private to the copy of the event that appears on
+		 * this calendar.
+		 * @return the value or {@code null} if none.
+		 */
+		public Map<String, String> getPrivateProperties() {
+			return privateProperties;
+		}
+
+		/**
+		 * Properties that are shared between copies of the event on other
+		 * attendees' calendars.
+		 * @return the value or {@code null} if none.
+		 */
+		public Map<String, String> getSharedProperties() {
+			return sharedProperties;
+		}
+	}
+	
+	/**
+	 * A gadget that extends an event.
+	 */
+	public static class Gadget {
+		@JsonInclude(value = Include.NON_NULL)
+		private String type;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String title;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String link;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String iconLink;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Integer width;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Integer height;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private DisplayMode display;
+
+		@JsonInclude(value = Include.NON_NULL)
+	    private Map<String, String> preferences;
+
+		/**
+		 * The gadget's type.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getType() {
+			return type;
+		}
+		
+		/**
+		 * The gadget's title.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getTitle() {
+			return title;
+		}
+		
+		/**
+		 * The gadget's URL.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getLink() {
+			return link;
+		}
+		
+		/**
+		 * The gadget's icon URL.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getIconLink() {
+			return iconLink;
+		}
+
+		/**
+		 * The gadget's width in pixels.
+		 * @return the value or {@code null} if none.
+		 */
+		public Integer getWidth() {
+			return width;
+		}
+		
+		/**
+		 * The gadget's height in pixels.
+		 * @return the value or {@code null} if none.
+		 */
+		public Integer getHeight() {
+			return height;
+		}
+		
+		/**
+		 * The gadget's display mode.
+		 * @return the value or {@code null} if none.
+		 */
+		public DisplayMode getDisplay() {
+			return display;
+		}
+		
+		/**
+		 * The gadget's preferences.
+		 * @return the value or {@code null} if none.
+		 */
+		public Map<String, String> getPreferences() {
+			return preferences;
+		}
+	}
+	
+	/**
+	 * Details of the overrides to reminders.
+	 */
+	public static class ReminderOverride {
+		@JsonInclude(value = Include.NON_NULL)
+		private NotificationMethod method;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private Integer minutes;
+		
+		/**
+		 * The method used by this reminder.
+		 * @return the value or {@code null} if none.
+		 */
+		public NotificationMethod getMethod() {
+			return method;
+		}
+		
+		/**
+		 * The number of minutes before the start of the event when this reminder
+		 * should trigger.
+		 * @return the value or {@code null} if none.
+		 */
+		public Integer getMinutes() {
+			return minutes;
+		}
+	}
+
+	/**
+	 * Information about the event's reminders for the authenticated user.
+	 */
+	public static class Reminders {
+		@JsonInclude(value = Include.NON_NULL)
+		private Boolean useDefault;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private List<ReminderOverride> overrides;
+		
+		/**
+		 * Whether the default reminders of the calendar apply to this event.
+		 * @return the value or {@code null} if none.
+		 */
+		public Boolean isUseDefault() {
+			return useDefault;
+		}
+		
+		/**
+		 * If the event doesn't use the default reminders, this returns the list of
+		 * reminders specific to the event, or, if not set, indicates that no reminders
+		 * are set for this event.
+		 * @return the value or {@code null} if none.
+		 */
+		public List<ReminderOverride> getOverrides() {
+			return overrides;
+		}
+	}
+
+	/**
+	 * Source from which an event was created; for example a web page, an email message
+	 * or any document identifiable by an URL using HTTP/HTTPS protocol.
+	 * Accessible only by the creator of the event.
+	 */
+	public static class Source {
+		@JsonInclude(value = Include.NON_NULL)
+		private String url;
+
+		@JsonInclude(value = Include.NON_NULL)
+		private String title;
+
+		/**
+		 * The URL of the source pointing to a resource.
+		 * The URL's protocol will be HTTP or HTTPS.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getUrl() {
+			return url;
+		}
+		
+		/**
+		 * The title of the source; for example a title of a web page or an email
+		 * subject.
+		 * @return the value or {@code null} if none.
+		 */
+		public String getTitle() {
+			return title;
+		}
+	}
+	
+	@JsonInclude(value = Include.NON_NULL)
+	private EventStatus status;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String htmlLink;
+
+	@JsonInclude(value = Include.NON_NULL)
+	@JsonFormat(shape=STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone="UTC")
+	private Date created;
+
+	@JsonInclude(value = Include.NON_NULL)
+	@JsonFormat(shape=STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone="UTC")
+	private Date updated;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String summary;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String description;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String location;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String colorId;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Creator creator;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Organizer organizer;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private DateTimeTimezone start;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private DateTimeTimezone end;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Boolean endTimeUnspecified;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private List<String> recurrence;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String recurringEventId;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private DateTimeTimezone originalStartTime;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Transparency transparency;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Visibility visibility;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String iCalUID;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Integer sequence;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private List<Attendee> attendees;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Boolean attendeesOmitted;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private ExtendedProperties extendedProperties;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private String hangoutLink;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Gadget gadget;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Boolean anyoneCanAddSelf;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Boolean guestsCanInviteOthers;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Boolean guestsCanModify;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Boolean guestsCanSeeOtherGuests;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Boolean privateCopy;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Boolean locked;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Reminders reminders;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private Source source;
+
+	/**
+	 * Constructor protected so instances must be retrieved from Google Calendar
+	 * itself.
+	 * Only some of the possible modifications are currently implemented.
+	 */
+	protected Event() {
+		super();
+		
+		presetBooleansThatDefaultToTrue();
+	}
+	
+	private void presetBooleansThatDefaultToTrue() {
+		guestsCanInviteOthers = true;
+		guestsCanSeeOtherGuests = true;
+	}
+
+	/**
+	 * The status of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public EventStatus getStatus() {
+		return status;
+	}
+	
+	/**
+	 * An absolute link to this event in the Google Calendar Web UI.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getHtmlLink() {
+		return htmlLink;
+	}
+	
+	/**
+	 * The creation time of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public Date getCreated() {
+		return created;
+	}
+	
+	/**
+	 * The last modification time of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public Date getUpdated() {
+		return updated;
+	}
+	
+	/**
+	 * The title of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getSummary() {
+		return summary;
+	}
+	
+	/**
+	 * The description of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getDescription() {
+		return description;
+	}
+	
+	/**
+	 * The geographic location of this event as free-form text.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getLocation() {
+		return location;
+	}
+	
+	/**
+	 * The colour of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getColorId() {
+		return colorId;
+	}
+	
+	/**
+	 * The creator of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public Creator getCreator() {
+		return creator;
+	}
+	
+	/**
+	 * The organizer of this event.
+	 * If the organizer is also an attendee, this is indicated with a separate entry in
+	 * attendees with the organizer field set to True.
+	 * @return the value or {@code null} if none.
+	 */
+	public Organizer getOrganizer() {
+		return organizer;
+	}
+	
+	/**
+	 * The (inclusive) start time of this event.
+	 * For a recurring event, this is the start time of the first instance.
+	 * @return the value or {@code null} if none.
+	 */
+	public DateTimeTimezone getStart() {
+		return start;
+	}
+	
+	/**
+	 * The (exclusive) end time of this event.
+	 * For a recurring event, this is the end time of the first instance.
+	 * @return the value or {@code null} if none.
+	 */
+	public DateTimeTimezone getEnd() {
+		return end;
+	}
+	
+	/**
+	 * Whether the end time is actually unspecified.
+	 * An end time is still provided for compatibility reasons, even if this attribute is
+	 * set to {@code true}.
+	 * If {@code true}, the end time should be disregarded.
+	 * @return the value or {@code null} if none.
+	 */
+	public Boolean isEndTimeUnspecified() {
+		return endTimeUnspecified;
+	}
+	
+	/**
+	 * For an instance of a recurring event, return this event ID of the recurring event
+	 * itself.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getRecurringEventId() {
+		return recurringEventId;
+	}
+	
+	/**
+	 * For an instance of a recurring event, return the time at which this event
+	 * would start according to the recurrence data in the recurring event identified
+	 * by {@link #recurringEventId}.
+	 * @return the value or {@code null} if none.
+	 */
+	public DateTimeTimezone getOriginalStartTime() {
+		return originalStartTime;
+	}
+	
+	/**
+	 * Whether this event blocks time on the calendar.
+	 * @return the value or {@code null} if none.
+	 */
+	public Transparency getTransparency() {
+		return transparency;
+	}
+	
+	/**
+	 * The visibility of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public Visibility getVisibility() {
+		return visibility;
+	}
+	
+	/**
+	 * This event's ID in the iCalendar format.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getiCalUID() {
+		return iCalUID;
+	}
+	
+	/**
+	 * The sequence number as per iCalendar.
+	 * @return the value or {@code null} if none.
+	 */
+	public Integer getSequence() {
+		return sequence;
+	}
+	
+	/**
+	 * Whether attendees may have been omitted from this event's representation.
+	 * When retrieving an event, this may be due to a restriction specified by the
+	 * maxAttendee query parameter.
+	 * @return the value or {@code null} if none.
+	 */
+	public Boolean isAttendeesOmitted() {
+		return attendeesOmitted;
+	}
+	
+	/**
+	 * An absolute link to the Google+ hangout associated with this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public String getHangoutLink() {
+		return hangoutLink;
+	}
+	
+	/**
+	 * Whether anyone can invite themselves to this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public Boolean isAnyoneCanAddSelf() {
+		return anyoneCanAddSelf;
+	}
+	
+	/**
+	 * Whether attendees other than the organizer can invite others to this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public Boolean isGuestsCanInviteOthers() {
+		return guestsCanInviteOthers;
+	}
+	
+	/**
+	 * Whether attendees other than the organizer can modify this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public Boolean isGuestsCanModify() {
+		return guestsCanModify;
+	}
+	
+	/**
+	 * Whether attendees other than the organizer can see who this event's
+	 * attendees are.
+	 * @return the value or {@code null} if none.
+	 */
+	public Boolean isGuestsCanSeeOtherGuests() {
+		return guestsCanSeeOtherGuests;
+	}
+	
+	/**
+	 * Whether this is a private event copy where changes are not shared with
+	 * other copies on other calendars.
+	 * @return the value or {@code null} if none.
+	 */
+	public Boolean isPrivateCopy() {
+		return privateCopy;
+	}
+	
+	/**
+	 * Whether this is a locked event copy where no changes can be made to the
+	 * main event fields "summary", "description", "location", "start", "end" or "recurrence".
+	 * @return the value or {@code null} if none.
+	 */
+	public Boolean isLocked() {
+		return locked;
+	}
+	
+	/**
+	 * A list of RRULE, EXRULE, RDATE and EXDATE lines for a recurring event.
+	 * This field is omitted for single events or <em>instances</em> of recurring events.
+	 * @return the value or {@code null} if none.
+	 */
+	public List<String> getRecurrence() {
+		return recurrence;
+	}
+	
+	/**
+	 * The attendees of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public List<Attendee> getAttendees() {
+		return attendees;
+	}
+	
+	/**
+	 * The extended properties of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public ExtendedProperties getExtendedProperties() {
+		return extendedProperties;
+	}
+	
+	/**
+	 * A gadget that extends this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public Gadget getGadget() {
+		return gadget;
+	}
+	
+	/**
+	 * Information about this event's reminders for the authenticated user.
+	 * @return the value or {@code null} if none.
+	 */
+	public Reminders getReminders() {
+		return reminders;
+	}
+	
+	/**
+	 * The source of an event from which this event was created; for example a
+	 * web page, an email message or any document identifiable by an URL using HTTP/HTTPS
+	 * protocol.
+	 * Accessible only by the creator of this event.
+	 * @return the value or {@code null} if none.
+	 */
+	public Source getSource() {
+		return source;
+	}
+
+	/**
+	 * Sets the status of this event.
+	 * @param status the new status, or {@code null} for none.
+	 * @return this event, for chaining.
+	 */
+	public Event setStatus(EventStatus status) {
+		this.status = status;
+		return this;
+	}
+	
+	/**
+	 * Sets the title of this event.
+	 * @param summary the new title.
+	 * @return this event, to allow chaining.
+	 */
+	public Event setSummary(String summary) {
+		this.summary = summary;
+		return this;
+	}
+
+	/**
+	 * Sets the location of this event.
+	 * @param location the new location, or {@code null} for none.
+	 * @return this event, to allow chaining.
+	 */
+	public Event setLocation(String location) {
+		this.location = location;
+		return this;
+	}
+	
+	/**
+	 * Replaces the list of RRULE, EXRULE, RDATE and EXDATE lines for a recurring event.
+	 * @param list the new list, or {@code null} for none.
+	 * @return this event, to allow chaining.
+	 */
+	public Event setRecurrence(List<String> list) {
+		this.recurrence = list;
+		return this;
+	}
+
+	/**
+	 * Sets whether attendees other than the organizer can invite others to the event. 
+	 * @param guestsCanInviteOthers the new value.
+	 * @return this event, to allow chaining.
+	 */
+	public Event setGuestsCanInviteOthers(Boolean guestsCanInviteOthers) {
+		this.guestsCanInviteOthers = guestsCanInviteOthers;
+		return this;
+	}
+
+	/**
+	 * Sets whether attendees other than the organizer can see who the event's attendees
+	 * are.
+	 * @param guestsCanSeeOtherGuests the new value.
+	 * @return this event, to allow chaining.
+	 */
+	public Event setGuestsCanSeeOtherGuests(Boolean guestsCanSeeOtherGuests) {
+		this.guestsCanSeeOtherGuests = guestsCanSeeOtherGuests;
+		return this;
+	}
+
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/EventListQueryBuilder.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/EventListQueryBuilder.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.springframework.social.google.api.query.ApiQueryBuilder;
+
+/**
+ * Constructs queries for listing the events in a calendar, following the builder pattern.
+ * The {@link #getPage()} method returns an {@link EventPage} containing {@link Event} instances.
+ * <p>
+ * See
+ * <a href="http://developers.google.com/google-apps/calendar/v3/reference/events/list">
+ * http://developers.google.com/google-apps/calendar/v3/reference/events/list</a>
+ * for details of the parameters.
+ * </p>
+ * 
+ * @author Martin Wink
+ */
+public interface EventListQueryBuilder extends ApiQueryBuilder<EventListQueryBuilder, EventPage> {
+	/**
+	 * Specifies whether to always include a value in the email field for the organizer,
+	 * creator and attendees, even if no real email is available (i.e. a generated,
+	 * non-working value will be provided). The use of this option is discouraged and
+	 * should only be used by clients which cannot handle the absence of an email address
+	 * value in the mentioned places. Optional. The default is {@code false}.
+	 * @param alwaysIncludeEmail whether to always include email.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder alwaysIncludeEmail(boolean alwaysIncludeEmail);
+	
+	/**
+	 * Specifies event ID in the iCalendar format to be included in the response. Optional.
+	 * @param iCalUID the event ID in the iCalendar format.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder iCalUID(String iCalUID);
+	
+	/**
+	 * The maximum number of attendees to include in the response. If there are more than
+	 * the specified number of attendees, only the participant is returned. Optional.
+	 * @param maxAttendees the maximum number of attendees to include.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder maxAttendees(int maxAttendees);
+	
+	/**
+	 * The order of the events returned in the result. Optional. The default is an
+	 * unspecified, stable order. 
+	 * @param orderBy the required order.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder orderBy(OrderBy orderBy);
+	
+	/**
+	 * Whether to include deleted events (with status equals "cancelled") in the result.
+	 * Cancelled instances of recurring events (but not the underlying recurring event)
+	 * will still be included if {@link #showDeleted} and {@link #singleEvents} are both
+	 * {@code false}. If {@link #showDeleted} and {@link #singleEvents} are both
+	 * {@code true}, only single instances of deleted events (but not the underlying
+	 * recurring events) are returned. Optional. The default is {@code false}.
+	 * @param showDeleted whether to include deleted events.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder showDeleted(boolean showDeleted);
+	
+	/**
+	 * Whether to include hidden invitations in the result. Optional.
+	 * The default is {@code false}.
+	 * @param showHiddenInvitations whether to include hidden invitations.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder showHiddenInvitations(boolean showHiddenInvitations);
+	
+	/**
+	 * Whether to expand recurring events into instances and only return single one-off
+	 * events and instances of recurring events, but not the underlying recurring events
+	 * themselves. Optional. The default is {@code false}.
+	 * @param singleEvents whether to expand recurring events into single events. 
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder singleEvents(boolean singleEvents);
+	
+	/**
+	 * Lower bound (inclusive) for an event's end time to filter by. Optional.
+	 * The default is not to filter by end time.
+	 * @param timeMin the detailed time.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder timeMin(Date timeMin);
+	
+	/**
+	 * Lower bound (inclusive) for an event's end time to filter by. Optional.
+	 * The default is not to filter by end time.
+	 * @param year the full year, for example 2014.
+	 * @param month the month, for example 1 for January.
+	 * @param day the day in the month, starting at 1.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder timeMin(int year, int month, int day);
+	
+	/**
+	 * Upper bound (exclusive) for an event's start time to filter by. Optional.
+	 * The default is not to filter by start time.
+	 * @param timeMax the detailed time.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder timeMax(Date timeMax);
+	
+	/**
+	 * Upper bound (exclusive) for an event's start time to filter by. Optional.
+	 * The default is not to filter by start time.
+	 * @param year the full year, for example 2014.
+	 * @param month the month, for example 1 for January.
+	 * @param day the day in the month, starting at 1.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder timeMax(int year, int month, int day);
+	
+	/**
+	 * Lower bound for an event's last modification time to filter by.
+	 * When specified, entries deleted since this time will always be included regardless
+	 * of showDeleted.
+	 * Optional. The default is not to filter by last modification time.
+	 * @param updatedMin the lower bound for an event's last modification time.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder updatedMin(Date updatedMin);
+	
+	/**
+	 * Time zone used in the response. Optional. The default is the time zone of the calendar.
+	 * @param timeZone the time zone.
+	 * @return this {@code EventListQueryBuilder}, for refining the query.
+	 */
+	EventListQueryBuilder timeZone(TimeZone timeZone);
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/EventPage.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/EventPage.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.query.ApiPage;
+
+/**
+ * A specialized {@link ApiPage} containing {@link Event} instances.
+ * 
+ * @author Martin Wink
+ */
+public class EventPage extends ApiPage<Event> {
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/EventStatus.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/EventStatus.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.calendar.impl.EventStatusDeserializer;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Enumeration representing an event's status.
+ * 
+ * @author Martin Wink
+ */
+@JsonSerialize(using=ApiEnumSerializer.class)
+@JsonDeserialize(using=EventStatusDeserializer.class)
+public enum EventStatus {
+	/**
+	 * "confirmed" - The event is confirmed. This is the default status.
+	 */
+	CONFIRMED,
+	
+	/**
+	 * "tentative" - The event is tentatively confirmed.
+	 */
+	TENTATIVE,
+	
+	/**
+	 * "cancelled" - The event is cancelled.
+	 */
+	CANCELLED
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/NotificationMethod.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/NotificationMethod.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.calendar.impl.NotificationMethodDeserializer;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Enumeration representing a notification method.
+ * 
+ * @author Martin Wink
+ */
+@JsonSerialize(using=ApiEnumSerializer.class)
+@JsonDeserialize(using=NotificationMethodDeserializer.class)
+public enum NotificationMethod {
+	/**
+	 * "email" - Reminders are sent via email.
+	 */
+	EMAIL,
+	
+	/**
+	 *  "sms" - Reminders are sent via SMS.
+	 */
+	SMS,
+	
+	/**
+	 * "popup" - Reminders are sent via a UI popup.
+	 */
+	POPUP
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/NotificationType.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/NotificationType.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.calendar.impl.NotificationTypeDeserializer;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Enumeration representing a notification type.
+ * 
+ * @author Martin Wink
+ */
+@JsonSerialize(using=ApiEnumSerializer.class)
+@JsonDeserialize(using=NotificationTypeDeserializer.class)
+public enum NotificationType {
+	/**
+	 * "eventCreation" - Notification sent when a new event is put on the calendar.
+	 */
+	EVENT_CREATION,
+	
+	/**
+	 * "eventChange" - Notification sent when an event is changed.
+	 */
+	EVENT_CHANGE,
+	
+	/**
+	 * "eventCancellation" - Notification sent when an event is cancelled.
+	 */
+	EVENT_CANCELLATION,
+	
+	/**
+	 * "eventResponse" - Notification sent when an event is changed.
+	 */
+	EVENT_RESPONSE,
+	
+	/**
+	 * "agenda" - An agenda with the events of the day (sent out in the morning).
+	 */
+	AGENDA
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/OrderBy.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/OrderBy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.calendar.impl.OrderByDeserializer;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Enumeration representing the ordering of results.
+ * 
+ * @author Martin Wink
+ */
+@JsonSerialize(using=ApiEnumSerializer.class)
+@JsonDeserialize(using=OrderByDeserializer.class)
+public enum OrderBy {
+	/**
+	 * "startTime": Order by the start date/time (ascending).
+	 * This is only available when querying single events (i.e. the parameter singleEvents
+	 * is {@code true}) otherwise a BAD REQUEST will result.
+	 */
+	START_TIME,
+	
+	/**
+	 * "updated": Order by last modification time (ascending).
+	 */
+	UPDATED
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/PermissionRole.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/PermissionRole.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.calendar.impl.PermissionRoleDeserializer;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Enumeration representing a user permission role in Google Calendar.
+ * 
+ * @author Martin Wink
+ */
+@JsonSerialize(using=ApiEnumSerializer.class)
+@JsonDeserialize(using=PermissionRoleDeserializer.class)
+public enum PermissionRole {
+	/**
+	 * "freeBusyReader" - Provides read access to free/busy information.
+	 */
+	FREE_BUSY_READER,
+	
+	/**
+	 * "reader" - Provides read access to the calendar.
+	 * Private events will appear to users with reader access, but event details will be
+	 * hidden.
+	 */
+	READER,
+	
+	/**
+	 * "writer" - Provides read and write access to the calendar.
+	 * Private events will appear to users with writer access, and event details will be
+	 * visible.
+	 */
+	WRITER,
+	
+	/**
+	 * "owner" - Provides ownership of the calendar.
+	 * This role has all of the permissions of the writer role with the additional ability
+	 * to see and manipulate ACLs.
+	 */
+	OWNER
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/QuickAddEventBuilder.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/QuickAddEventBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+
+/**
+ * Interface for constructing queries for adding a new event to a calendar, following the
+ * builder pattern.
+ * <p>(Currently only used internally within {@link CalendarOperations#quickAddEvent}.)</p>
+ * 
+ * @author Martin Wink
+ */
+public interface QuickAddEventBuilder extends UriQueryBuilder<QuickAddEventBuilder, Event> {
+	QuickAddEventBuilder text(String text);
+	QuickAddEventBuilder sendNotifications(boolean sendNotifications);
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Transparency.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Transparency.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.calendar.impl.TransparencyDeserializer;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Enumeration representing whether an event blocks time in the Calendar.
+ * 
+ * @author Martin Wink
+ */
+@JsonSerialize(using=ApiEnumSerializer.class)
+@JsonDeserialize(using=TransparencyDeserializer.class)
+public enum Transparency {
+	/**
+	 * "opaque" - The event blocks time on the calendar. This is the default value.
+	 */
+	OPAQUE,
+	
+	/**
+	 * "transparent" - The event does not block time on the calendar.
+	 */
+	TRANSPARENT
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/UpdateEventBuilder.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/UpdateEventBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+
+/**
+ * Interface for constructing queries for updating a existing event in a calendar,
+ * following the builder pattern.
+ * <p>(Currently only used internally within {@link CalendarOperations#updateEvent}.)</p>
+ * 
+ * @author Martin Wink
+ */
+public interface UpdateEventBuilder extends UriQueryBuilder<UpdateEventBuilder, Object> {
+	UpdateEventBuilder alwaysIncludeEmail(boolean alwaysIncludeEmail);
+	UpdateEventBuilder maxAttendees(int maxAttendees);
+	UpdateEventBuilder sendNotifications(boolean sendNotifications);
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/UriQueryBuilder.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/UriQueryBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import java.net.URI;
+
+import org.springframework.social.google.api.query.QueryBuilder;
+
+/**
+ * A super-interface for query builders where URIs are built instead of Strings.
+ * @param <Q> {@link UriQueryBuilder} type
+ * @param <T> Model type
+ * 
+ * @author Martin Wink
+ */
+public interface UriQueryBuilder<Q extends UriQueryBuilder<?, T>, T> extends QueryBuilder<Q, T> {
+	URI buildUri();
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Visibility.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Visibility.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import org.springframework.social.google.api.calendar.impl.VisibilityDeserializer;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Enumeration representing the visibility of an event.
+ * 
+ * @author Martin Wink
+ */
+@JsonSerialize(using=ApiEnumSerializer.class)
+@JsonDeserialize(using=VisibilityDeserializer.class)
+public enum Visibility {
+	/**
+	 * "default" - Uses the default visibility for events on the calendar.
+	 * This is the default value.
+	 */
+	DEFAULT,
+	
+	/**
+	 * "public" - The event is public and event details are visible to all readers of
+	 * the calendar.
+	 */
+	PUBLIC,
+	
+	/**
+	 * "private" - The event is private and only event attendees may view event details.
+	 */
+	PRIVATE,
+	
+	/**
+	 * "confidential" - The event is private. This value is provided for compatibility
+	 * reasons.
+	 */
+	CONFIDENTIAL
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/AttendeeStatusDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/AttendeeStatusDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.AttendeeStatus;
+import org.springframework.social.google.api.impl.ApiEnumDeserializer;
+
+/**
+ * {@link ApiEnumDeserializer} for {@link AttendeeStatus}.
+ * 
+ * @author Martin Wink
+ */
+public class AttendeeStatusDeserializer extends ApiEnumDeserializer<AttendeeStatus> {
+	public AttendeeStatusDeserializer() {
+		super(AttendeeStatus.class);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/CalendarGetQueryBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/CalendarGetQueryBuilderImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import java.text.MessageFormat;
+
+/**
+ * {@link UriQueryBuilderImpl} subclass for getting a single calendar.
+ * 
+ * @author Martin Wink
+ */
+public class CalendarGetQueryBuilderImpl extends UriQueryBuilderImpl<CalendarGetQueryBuilderImpl, Object> {
+
+	public CalendarGetQueryBuilderImpl(String urlTemplate, String calendarId) {
+		super(MessageFormat.format(urlTemplate, encode(calendarId)));
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/CalendarListQueryBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/CalendarListQueryBuilderImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.CalendarPage;
+import org.springframework.social.google.api.calendar.CalendarListQueryBuilder;
+import org.springframework.social.google.api.calendar.PermissionRole;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+import org.springframework.social.google.api.query.impl.ApiQueryBuilderImpl;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * {@link CalendarListQueryBuilder} implementation.
+ * 
+ * @author Martin Wink
+ */
+public class CalendarListQueryBuilderImpl extends ApiQueryBuilderImpl<CalendarListQueryBuilder, CalendarPage> implements CalendarListQueryBuilder {
+
+	public CalendarListQueryBuilderImpl(String feedUrl, Class<CalendarPage> type, RestTemplate restTemplate) {
+		super(feedUrl, type, restTemplate);
+	}
+
+	@Override
+	public CalendarListQueryBuilder showDeleted(boolean showDeleted) {
+		return appendQueryParam("showDeleted", showDeleted);
+	}
+
+	@Override
+	public CalendarListQueryBuilder showHidden(boolean showHidden) {
+		return appendQueryParam("showHidden", showHidden);
+	}
+
+	@Override
+	public CalendarListQueryBuilder minAccessRole(PermissionRole minAccessRole) {
+		return appendQueryParam("minAccessRole", ApiEnumSerializer.enumToString(minAccessRole));
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/CalendarTemplate.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/CalendarTemplate.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.Calendar;
+import org.springframework.social.google.api.calendar.CalendarListQueryBuilder;
+import org.springframework.social.google.api.calendar.CalendarOperations;
+import org.springframework.social.google.api.calendar.CalendarPage;
+import org.springframework.social.google.api.calendar.DeleteEventBuilder;
+import org.springframework.social.google.api.calendar.Event;
+import org.springframework.social.google.api.calendar.EventListQueryBuilder;
+import org.springframework.social.google.api.calendar.EventPage;
+import org.springframework.social.google.api.calendar.QuickAddEventBuilder;
+import org.springframework.social.google.api.impl.AbstractGoogleApiOperations;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * {@link CalendarOperations} implementation.
+ * 
+ * @author Martin Wink
+ */
+public class CalendarTemplate extends AbstractGoogleApiOperations implements CalendarOperations {
+	
+	private static final String CALENDAR_BASE_URL = "https://www.googleapis.com/calendar/v3";
+	
+	public CalendarTemplate(RestTemplate restTemplate, boolean isAuthorized) {
+		super(restTemplate, isAuthorized);
+		Assert.notNull(restTemplate, "RestTemplate must not be null");
+	}
+
+	@Override
+	public CalendarListQueryBuilder calendarListQuery() {
+		return new CalendarListQueryBuilderImpl(CALENDAR_BASE_URL + "/users/me/calendarList", CalendarPage.class, restTemplate);
+	}
+
+	@Override
+	public EventListQueryBuilder eventListQuery(String calendarId) {
+		Assert.notNull(calendarId, "CalendarId must not be null");
+		return new EventListQueryBuilderImpl(CALENDAR_BASE_URL + "/calendars/{0}/events", calendarId, EventPage.class, restTemplate);
+	}
+
+	@Override
+	public Calendar getCalendar(String calendarId) {
+		Assert.notNull(calendarId, "CalendarId must not be null");
+		CalendarGetQueryBuilderImpl builder = new CalendarGetQueryBuilderImpl(CALENDAR_BASE_URL + "/users/me/calendarList/{0}", calendarId); 
+		return restTemplate.getForObject(builder.buildUri(), Calendar.class);
+	}
+
+	@Override
+	public Event getEvent(String calendarId, String eventId) {
+		Assert.notNull(calendarId, "CalendarId must not be null");
+		Assert.notNull(eventId, "EventId must not be null");
+		EventGetQueryBuilderImpl builder = new EventGetQueryBuilderImpl(CALENDAR_BASE_URL + "/calendars/{0}/events/{1}", calendarId, eventId); 
+		return restTemplate.getForObject(builder.buildUri(), Event.class);
+	}
+
+	@Override
+	public Event quickAddEvent(String calendarId, String specification, boolean sendNotifications) {
+		Assert.notNull(calendarId, "CalendarId must not be null");
+		Assert.notNull(specification, "Specification must not be null");
+		QuickAddEventBuilder builder = new QuickAddEventBuilderImpl(CALENDAR_BASE_URL + "/calendars/{0}/events/quickAdd", calendarId);
+		builder.text(specification).sendNotifications(sendNotifications);
+		return restTemplate.postForObject(builder.buildUri(), null, Event.class);
+	}
+
+	@Override
+	public void deleteEvent(String calendarId, String eventId, boolean sendNotifications) {
+		Assert.notNull(calendarId, "CalendarId must not be null");
+		Assert.notNull(eventId, "EventId must not be null");
+		DeleteEventBuilder builder = new DeleteEventBuilderImpl(CALENDAR_BASE_URL + "/calendars/{0}/events/{1}", calendarId, eventId);
+		builder.sendNotifications(sendNotifications);
+		restTemplate.delete(builder.buildUri());
+	}
+
+	@Override
+	public void updateEvent(String calendarId, Event event, boolean sendNotifications) {
+		Assert.notNull(calendarId, "CalendarId must not be null");
+		Assert.notNull(event, "Event must not be null");
+		UpdateEventBuilderImpl builder = new UpdateEventBuilderImpl(CALENDAR_BASE_URL + "/calendars/{0}/events/{1}", calendarId, event.getId());
+		builder.sendNotifications(sendNotifications);
+		restTemplate.put(builder.buildUri(), event);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/DateTimeDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/DateTimeDeserializer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+/**
+ * {@link JsonDeserializer} for {@link Date}.
+ * Required because date times returned in events sometimes include milliseconds, sometimes not,
+ * so this implementation is more forgiving.
+ * 
+ * @author Martin Wink
+ */
+public class DateTimeDeserializer extends JsonDeserializer<Date> {
+	
+	private static final SimpleDateFormat[] DATE_FORMATS = new SimpleDateFormat[] {
+		new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"),
+		new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
+		new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"),
+		new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"),
+		new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX"),
+		new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+	};
+
+	static {
+		final TimeZone timeZone = TimeZone.getTimeZone("GMT");
+		for (SimpleDateFormat format : DATE_FORMATS) {
+			format.setTimeZone(timeZone);
+		}
+	}
+
+	@Override
+	public Date deserialize(JsonParser jp, DeserializationContext ctxt) throws JsonParseException, IOException {
+		String valueAsString = jp.getValueAsString();
+		if (valueAsString != null && valueAsString.length() > 0) {
+			for (SimpleDateFormat format : DATE_FORMATS) {
+				try {
+					Date parsedDate = format.parse(valueAsString);
+					return parsedDate;
+				} catch (ParseException e) {
+					// Ignore, and try the next format.
+				}
+			}
+			throw new JsonParseException("Date-time unparseable: \"" + valueAsString + "\".", jp.getCurrentLocation());
+		}
+		return null;
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/DateTimeSerializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/DateTimeSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * {@link JsonSerializer} for {@link Date}.
+ * 
+ * @author Martin Wink
+ */
+public class DateTimeSerializer extends JsonSerializer<Date> {
+	private static final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US);
+	
+	static {
+		final TimeZone timeZone = TimeZone.getTimeZone("GMT");
+		format.setTimeZone(timeZone);
+	}
+
+	@Override
+	public void serialize(Date value, JsonGenerator jgen, SerializerProvider provider)
+			throws IOException, JsonProcessingException {
+		jgen.writeString(format.format(value));
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/DeleteEventBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/DeleteEventBuilderImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import java.text.MessageFormat;
+
+import org.springframework.social.google.api.calendar.DeleteEventBuilder;
+
+/**
+ * {@link DeleteEventBuilder} implementation.
+ * 
+ * @author Martin Wink
+ */
+public class DeleteEventBuilderImpl extends UriQueryBuilderImpl<DeleteEventBuilder, Object> implements DeleteEventBuilder {
+	public DeleteEventBuilderImpl(String urlTemplate, String calendarId, String eventId) {
+		super(MessageFormat.format(urlTemplate, encode(calendarId), encode(eventId)));
+	}
+
+	public DeleteEventBuilder sendNotifications(boolean sendNotifications) {
+		return appendQueryParam("sendNotifications", sendNotifications);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/DisplayModeDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/DisplayModeDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.DisplayMode;
+import org.springframework.social.google.api.impl.ApiEnumDeserializer;
+
+/**
+ * {@link ApiEnumDeserializer} for {@link DisplayMode}.
+ * 
+ * @author Martin Wink
+ */
+public class DisplayModeDeserializer extends ApiEnumDeserializer<DisplayMode> {
+	public DisplayModeDeserializer() {
+		super(DisplayMode.class);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/EventGetQueryBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/EventGetQueryBuilderImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import java.text.MessageFormat;
+
+/**
+ * {@link UriQueryBuilderImpl} subclass for getting a single event.
+ * 
+ * @author Martin Wink
+ */
+public class EventGetQueryBuilderImpl extends UriQueryBuilderImpl<EventGetQueryBuilderImpl, Object> {
+
+	public EventGetQueryBuilderImpl(String urlTemplate, String calendarId, String eventId) {
+		super(MessageFormat.format(urlTemplate, encode(calendarId), encode(eventId)));
+	}
+	
+	// NB: Optional parameters not yet accommodated: alwaysIncludeEmail, maxAttendees, timeZone.
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/EventListQueryBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/EventListQueryBuilderImpl.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import java.text.MessageFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.springframework.social.google.api.calendar.EventPage;
+import org.springframework.social.google.api.calendar.EventListQueryBuilder;
+import org.springframework.social.google.api.calendar.OrderBy;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+import org.springframework.social.google.api.query.impl.ApiQueryBuilderImpl;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * {@link EventListQueryBuilder} implementation.
+ * 
+ * @author Martin Wink
+ */
+public class EventListQueryBuilderImpl extends ApiQueryBuilderImpl<EventListQueryBuilder, EventPage> implements EventListQueryBuilder {
+	
+	public EventListQueryBuilderImpl(String urlTemplate, String calendarId, Class<EventPage> type, RestTemplate restTemplate) {
+		super(MessageFormat.format(urlTemplate, encode(calendarId)), type, restTemplate);
+	}
+
+	private static final java.util.Calendar utcCalendar = java.util.Calendar.getInstance(TimeZone.getTimeZone("UTC"));;
+	private Date makeDate(int year, int month, int day) {
+		utcCalendar.setTimeInMillis(0);
+		utcCalendar.set(year, month - 1, day);
+		return utcCalendar.getTime();
+	}
+	
+	@Override
+	public EventListQueryBuilder fromPage(String pageToken) {
+		// Override because super class's implementation doesn't encode.
+		return super.fromPage(pageToken == null ? null : encode(pageToken));
+	}
+
+	@Override
+	public EventListQueryBuilder timeMin(Date timeMin) {
+		return appendQueryParam("timeMin", timeMin);
+	}
+
+	@Override
+	public EventListQueryBuilder timeMin(int year, int month, int day) {
+		return timeMin(makeDate(year, month, day));
+	}
+
+	@Override
+	public EventListQueryBuilder timeMax(Date timeMax) {
+		return appendQueryParam("timeMax", timeMax);
+	}
+
+	@Override
+	public EventListQueryBuilder timeMax(int year, int month, int day) {
+		return timeMax(makeDate(year, month, day));
+	}
+
+	@Override
+	public EventListQueryBuilder orderBy(OrderBy orderBy) {
+		return appendQueryParam("orderBy", ApiEnumSerializer.enumToString(orderBy));
+	}
+
+	@Override
+	public EventListQueryBuilder singleEvents(boolean singleEvents) {
+		return appendQueryParam("singleEvents", singleEvents);
+	}
+
+	@Override
+	public EventListQueryBuilder showDeleted(boolean showDeleted) {
+		return appendQueryParam("showDeleted", showDeleted);
+	}
+
+	@Override
+	public EventListQueryBuilder showHiddenInvitations(boolean showHiddenInvitations) {
+		return appendQueryParam("showHiddenInvitations", showHiddenInvitations);
+	}
+
+	@Override
+	public EventListQueryBuilder timeZone(TimeZone timeZone) {
+		return appendQueryParam("timeZone", timeZone.getID());
+	}
+
+	@Override
+	public EventListQueryBuilder updatedMin(Date updatedMin) {
+		return appendQueryParam("updatedMin", updatedMin);
+	}
+
+	@Override
+	public EventListQueryBuilder alwaysIncludeEmail(boolean alwaysIncludeEmail) {
+		return appendQueryParam("alwaysIncludeEmail", alwaysIncludeEmail);
+	}
+
+	@Override
+	public EventListQueryBuilder iCalUID(String iCalUID) {
+		return appendQueryParam("iCalUID", encode(iCalUID));
+	}
+
+	@Override
+	public EventListQueryBuilder maxAttendees(int maxAttendees) {
+		return appendQueryParam("maxAttendees", maxAttendees);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/EventStatusDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/EventStatusDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.EventStatus;
+import org.springframework.social.google.api.impl.ApiEnumDeserializer;
+
+/**
+ * {@link ApiEnumDeserializer} for {@link EventStatus}.
+ * 
+ * @author Martin Wink
+ */
+public class EventStatusDeserializer extends ApiEnumDeserializer<EventStatus> {
+	public EventStatusDeserializer() {
+		super(EventStatus.class);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/NotificationMethodDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/NotificationMethodDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.NotificationMethod;
+import org.springframework.social.google.api.impl.ApiEnumDeserializer;
+
+/**
+ * {@link ApiEnumDeserializer} for {@link NotificationMethod}.
+ * 
+ * @author Martin Wink
+ */
+public class NotificationMethodDeserializer extends ApiEnumDeserializer<NotificationMethod> {
+	public NotificationMethodDeserializer() {
+		super(NotificationMethod.class);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/NotificationTypeDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/NotificationTypeDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.NotificationType;
+import org.springframework.social.google.api.impl.ApiEnumDeserializer;
+
+/**
+ * {@link ApiEnumDeserializer} for {@link NotificationType}.
+ * 
+ * @author Martin Wink
+ */
+public class NotificationTypeDeserializer extends ApiEnumDeserializer<NotificationType> {
+	public NotificationTypeDeserializer() {
+		super(NotificationType.class);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/OrderByDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/OrderByDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.OrderBy;
+import org.springframework.social.google.api.impl.ApiEnumDeserializer;
+
+/**
+ * {@link ApiEnumDeserializer} for {@link OrderBy}.
+ * 
+ * @author Martin Wink
+ */
+public class OrderByDeserializer extends ApiEnumDeserializer<OrderBy> {
+	public OrderByDeserializer() {
+		super(OrderBy.class);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/PermissionRoleDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/PermissionRoleDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.PermissionRole;
+import org.springframework.social.google.api.impl.ApiEnumDeserializer;
+
+/**
+ * {@link ApiEnumDeserializer} for {@link PermissionRole}.
+ * 
+ * @author Martin Wink
+ */
+public class PermissionRoleDeserializer extends ApiEnumDeserializer<PermissionRole> {
+	public PermissionRoleDeserializer() {
+		super(PermissionRole.class);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/QuickAddEventBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/QuickAddEventBuilderImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import java.text.MessageFormat;
+
+import org.springframework.social.google.api.calendar.Event;
+import org.springframework.social.google.api.calendar.QuickAddEventBuilder;
+import org.springframework.util.Assert;
+
+/**
+ * {@link QuickAddEventBuilder} implementation.
+ * 
+ * @author Martin Wink
+ */
+public class QuickAddEventBuilderImpl extends UriQueryBuilderImpl<QuickAddEventBuilder, Event> implements QuickAddEventBuilder {
+	
+	public QuickAddEventBuilderImpl(String urlTemplate, String calendarId) {
+		super(MessageFormat.format(urlTemplate, encode(calendarId)));
+	}
+
+	@Override
+	public QuickAddEventBuilder text(String text) {
+		Assert.notNull(text, "Text must not be null");
+		return appendQueryParam("text", encode(text));
+	}
+
+	@Override
+	public QuickAddEventBuilder sendNotifications(boolean sendNotifications) {
+		return appendQueryParam("sendNotifications", sendNotifications);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/TimeZoneDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/TimeZoneDeserializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.TimeZone;
+
+/**
+ * {@link JsonDeserializer} for {@link TimeZone}.
+ * 
+ * @author Martin Wink
+ */
+public class TimeZoneDeserializer extends JsonDeserializer<TimeZone> {
+	@Override
+	public TimeZone deserialize(JsonParser jp, DeserializationContext ctxt)
+			throws JsonParseException, IOException {
+		return TimeZone.getTimeZone(jp.getValueAsString());
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/TimeZoneSerializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/TimeZoneSerializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.util.TimeZone;
+
+/**
+ * {@link JsonSerializer} for {@link TimeZone}.
+ * 
+ * @author Martin Wink
+ */
+public class TimeZoneSerializer extends JsonSerializer<TimeZone> {
+	@Override
+	public void serialize(TimeZone value, JsonGenerator jgen, SerializerProvider provider)
+			throws IOException, JsonProcessingException {
+		jgen.writeString(value.getID());
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/TransparencyDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/TransparencyDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.Transparency;
+import org.springframework.social.google.api.impl.ApiEnumDeserializer;
+
+/**
+ * {@link ApiEnumDeserializer} for {@link Transparency}.
+ * 
+ * @author Martin Wink
+ */
+public class TransparencyDeserializer extends ApiEnumDeserializer<Transparency> {
+	public TransparencyDeserializer() {
+		super(Transparency.class);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/UpdateEventBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/UpdateEventBuilderImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import java.text.MessageFormat;
+
+import org.springframework.social.google.api.calendar.UpdateEventBuilder;
+
+/**
+ * {@link UpdateEventBuilder} implementation.
+ * 
+ * @author Martin Wink
+ */
+public class UpdateEventBuilderImpl extends UriQueryBuilderImpl<UpdateEventBuilder, Object> implements UpdateEventBuilder {
+	public UpdateEventBuilderImpl(String urlTemplate, String calendarId, String eventId) {
+		super(MessageFormat.format(urlTemplate, encode(calendarId), encode(eventId)));
+	}
+
+	@Override
+	public UpdateEventBuilder alwaysIncludeEmail(boolean alwaysIncludeEmail) {
+		return appendQueryParam("alwaysIncludeEmail", alwaysIncludeEmail);
+	}
+
+	@Override
+	public UpdateEventBuilder maxAttendees(int maxAttendees) {
+		return appendQueryParam("maxAttendees", maxAttendees);
+	}
+
+	@Override
+	public UpdateEventBuilder sendNotifications(boolean sendNotifications) {
+		return appendQueryParam("sendNotifications", sendNotifications);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/UriQueryBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/UriQueryBuilderImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.springframework.social.google.api.calendar.UriQueryBuilder;
+import org.springframework.social.google.api.query.impl.QueryBuilderImpl;
+
+/**
+ * {@link UriQueryBuilder} implementation.
+ * 
+ * @author Martin Wink
+ */
+public abstract class UriQueryBuilderImpl<Q extends UriQueryBuilder<?, T>, T> extends QueryBuilderImpl<Q, T> implements UriQueryBuilder<Q, T> {
+
+	public UriQueryBuilderImpl(String urlTemplate) {
+		super(urlTemplate);
+	}
+	
+	public URI buildUri() {
+		try {
+			return new URI(super.build());
+		} catch (URISyntaxException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/VisibilityDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/impl/VisibilityDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar.impl;
+
+import org.springframework.social.google.api.calendar.Visibility;
+import org.springframework.social.google.api.impl.ApiEnumDeserializer;
+
+/**
+ * {@link ApiEnumDeserializer} for {@link Visibility}.
+ * 
+ * @author Martin Wink
+ */
+public class VisibilityDeserializer extends ApiEnumDeserializer<Visibility> {
+	public VisibilityDeserializer() {
+		super(Visibility.class);
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/package-info.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Spring Social's Service APIs for Google Calendar.
+ * <p>See the reference documentation at
+ * <a href="https://developers.google.com/google-apps/calendar/v3/reference/">
+ * https://developers.google.com/google-apps/calendar/v3/reference/
+ * </a>.
+ * </p>
+ */
+package org.springframework.social.google.api.calendar;

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/impl/GoogleTemplate.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/impl/GoogleTemplate.java
@@ -35,6 +35,8 @@ import org.springframework.social.google.api.plus.PlusOperations;
 import org.springframework.social.google.api.plus.impl.PlusTemplate;
 import org.springframework.social.google.api.tasks.TaskOperations;
 import org.springframework.social.google.api.tasks.impl.TaskTemplate;
+import org.springframework.social.google.api.calendar.CalendarOperations;
+import org.springframework.social.google.api.calendar.impl.CalendarTemplate;
 import org.springframework.social.oauth2.AbstractOAuth2ApiBinding;
 import org.springframework.social.oauth2.OAuth2Version;
 
@@ -53,13 +55,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Gabriel Axel
  */
 public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
-	
+
 	private String accessToken;
 
 	private PlusOperations plusOperations;
 	private TaskOperations taskOperations;
 	private DriveOperations driveOperations;
-	
+	private CalendarOperations calendarOperations;
+
 	/**
 	 * Creates a new instance of GoogleTemplate.
 	 * This constructor creates a new GoogleTemplate able to perform unauthenticated operations against Google+.
@@ -67,7 +70,7 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
 	public GoogleTemplate() {
 		initialize();
 	}
-	
+
 	/**
 	 * Creates a new instance of GoogleTemplate.
 	 * This constructor creates the FacebookTemplate using a given access token.
@@ -83,11 +86,12 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
 		plusOperations = new PlusTemplate(getRestTemplate(), isAuthorized());
 		taskOperations = new TaskTemplate(getRestTemplate(), isAuthorized());
 		driveOperations = new DriveTemplate(getRestTemplate(), isAuthorized());
+		calendarOperations = new CalendarTemplate(getRestTemplate(), isAuthorized());
 	}
-	
+
 	@Override
 	protected List<HttpMessageConverter<?>> getMessageConverters() {
-		
+
 		MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -95,10 +99,10 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
 		objectMapper.configure(FAIL_ON_EMPTY_BEANS, false);
 		objectMapper.setSerializationInclusion(NON_NULL);
 		jsonConverter.setObjectMapper(objectMapper);
-		
+
 		FormHttpMessageConverter formHttpMessageConverter = new FormHttpMessageConverter();
 		formHttpMessageConverter.addPartConverter(jsonConverter);
-		
+
 		List<HttpMessageConverter<?>> messageConverters = new ArrayList<HttpMessageConverter<?>>();
 		messageConverters.add(jsonConverter);
 		messageConverters.add(new ByteArrayHttpMessageConverter());
@@ -106,7 +110,7 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
 		messageConverters.add(new ResourceHttpMessageConverter());
 		return messageConverters;
 	}
-	
+
 	@Override
 	protected OAuth2Version getOAuth2Version() {
 		return OAuth2Version.BEARER;
@@ -121,12 +125,17 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
 	public TaskOperations taskOperations() {
 		return taskOperations;
 	}
-	
+
 	@Override
 	public DriveOperations driveOperations() {
 		return driveOperations;
 	}
-	
+
+	@Override
+	public CalendarOperations calendarOperations() {
+		return calendarOperations;
+	}
+
 	@Override
 	public String getAccessToken() {
 		return accessToken;

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/query/impl/ApiQueryBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/query/impl/ApiQueryBuilderImpl.java
@@ -15,11 +15,8 @@
  */
 package org.springframework.social.google.api.query.impl;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
-
 import org.springframework.social.google.api.query.ApiPage;
 import org.springframework.social.google.api.query.ApiQueryBuilder;
 import org.springframework.social.google.api.query.QueryBuilder;
@@ -36,14 +33,6 @@ public class ApiQueryBuilderImpl<Q extends ApiQueryBuilder<?, T>, T extends ApiP
 	private final Class<T> type;
 	private final RestTemplate restTemplate;
 
-	protected static String encode(String text) {
-		try {
-			return URLEncoder.encode(text, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new IllegalStateException(e);
-		}
-	}
-	
 	public ApiQueryBuilderImpl(Class<T> type, RestTemplate restTemplate) {
 		this.type = type;
 		this.restTemplate = restTemplate;

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/query/impl/QueryBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/query/impl/QueryBuilderImpl.java
@@ -17,6 +17,8 @@ package org.springframework.social.google.api.query.impl;
 
 import static org.springframework.util.StringUtils.hasText;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -34,10 +36,18 @@ import org.springframework.social.google.api.query.QueryBuilder;
  */
 public abstract class QueryBuilderImpl<Q extends QueryBuilder<?, T>, T> implements QueryBuilder<Q, T> {
 
-	private static final Format dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSS'Z'");
+	private static final Format dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 	
 	protected String feedUrl;
 	private Map<String, String> params = new HashMap<String, String>();	
+	
+	protected static String encode(String text) {
+		try {
+			return URLEncoder.encode(text, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			throw new IllegalStateException(e);
+		}
+	}
 	
 	protected QueryBuilderImpl() {
 	}

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_CalendarJsonTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_CalendarJsonTests.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.junit.Test;
+import org.springframework.social.google.api.AbstractGoogleApiTest;
+
+public class CalendarTemplate_CalendarJsonTests extends AbstractGoogleApiTest {
+
+	@Test
+	public void listCalendars() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_calendars"), APPLICATION_JSON));
+
+		CalendarPage calPage = google.calendarOperations().calendarListQuery().getPage();
+
+		assertNotNull(calPage);
+		assertNull(calPage.getNextPageToken());
+		assertEquals("\"0000000000000000\"", calPage.getEtag());
+		
+		assertEquals(5, calPage.getItems().size());
+		Calendar cal0 = calPage.getItems().get(0);
+		Calendar cal1 = calPage.getItems().get(1);
+		Calendar cal2 = calPage.getItems().get(2);
+		Calendar cal3 = calPage.getItems().get(3);
+		Calendar cal4 = calPage.getItems().get(4);
+
+		// Test each field in turn, with different values set in different calendars.
+		//	String summary;
+		//	String description;
+		//	String location;
+		//	String timezone;
+		//	String summaryOverride;
+		//	String colorId;
+		//	String backgroundColor;
+		//	String foregroundColor;
+		//	boolean hidden;
+		//	boolean selected;
+		//	PermissionRole accessRole;
+		//	List<DefaultReminder> defaultReminders;
+		//	NotificationSettings notificationSettings;
+		//	boolean primary;
+		//	boolean deleted;
+
+		assertEquals("martxw@gmail.com", cal0.getId());
+		assertEquals("en.uk#holiday@group.v.calendar.google.com", cal1.getId());
+		assertEquals("missing_values#martxw@gmail.com", cal2.getId());
+		assertEquals("alternate_values_1#martxw@gmail.com", cal3.getId());
+		assertEquals("alternate_values_2#martxw@gmail.com", cal4.getId());
+
+		assertEquals("\"0000000000000000\"", cal0.getEtag());
+		assertEquals("\"0000000000000001\"", cal1.getEtag());
+		assertEquals("\"0000000000000002\"", cal2.getEtag());
+		assertEquals("\"0000000000000003\"", cal3.getEtag());
+		assertEquals("\"0000000000000004\"", cal4.getEtag());
+
+		assertEquals("martxw@gmail.com", cal0.getSummary());
+		assertEquals("Holidays in United Kingdom", cal1.getSummary());
+		assertNull(cal2.getSummary());
+		assertEquals("", cal3.getSummary());
+		assertEquals("", cal4.getSummary());
+		
+		assertNull(cal0.getDescription());
+		assertEquals("Holidays and Observances in United Kingdom", cal1.getDescription());
+		assertNull(cal2.getDescription());
+		assertEquals("", cal3.getDescription());
+		assertEquals("", cal4.getDescription());
+		
+		assertNull(cal0.getLocation());
+		assertNull(cal1.getLocation());
+		assertNull(cal2.getLocation());
+		assertEquals("Somewhere", cal3.getLocation());
+		assertEquals("Somewhere", cal4.getLocation());
+		
+		assertEquals("Europe/London", cal0.getTimeZone().getID());
+		assertEquals("Europe/London", cal1.getTimeZone().getID());
+		assertNull(cal2.getTimeZone());
+		assertEquals("Europe/Paris", cal3.getTimeZone().getID());
+		// Empty timeZone => GMT
+		assertEquals("GMT", cal4.getTimeZone().getID());
+		
+		assertNull(cal0.getSummaryOverride());
+		assertNull(cal1.getSummaryOverride());
+		assertNull(cal2.getSummaryOverride());
+		assertEquals("My title", cal3.getSummaryOverride());
+		assertEquals("", cal4.getSummaryOverride());
+		
+		assertEquals("15", cal0.getColorId());
+		assertEquals("2", cal1.getColorId());
+		assertNull(cal2.getColorId());
+		assertEquals("", cal3.getColorId());
+		assertEquals("", cal4.getColorId());
+		
+		assertEquals("#9fc6e7", cal0.getBackgroundColor());
+		assertEquals("#d06b64", cal1.getBackgroundColor());
+		assertNull(cal2.getBackgroundColor());
+		assertEquals("", cal3.getBackgroundColor());
+		assertEquals("", cal4.getBackgroundColor());
+		
+		assertEquals("#000000", cal0.getForegroundColor());
+		assertEquals("#000000", cal1.getForegroundColor());
+		assertNull(cal2.getForegroundColor());
+		assertEquals("", cal3.getForegroundColor());
+		assertEquals("", cal4.getForegroundColor());
+		
+		assertEquals(false, cal0.isHidden());
+		assertEquals(false, cal1.isHidden());
+		assertEquals(false, cal2.isHidden());
+		assertEquals(true, cal3.isHidden());
+		assertEquals(true, cal4.isHidden());
+		
+		assertEquals(true, cal0.isSelected());
+		assertEquals(true, cal1.isSelected());
+		assertEquals(false, cal2.isSelected());
+		assertEquals(false, cal3.isSelected());
+		assertEquals(false, cal4.isSelected());
+		
+		assertEquals(PermissionRole.OWNER, cal0.getAccessRole());
+		assertEquals(PermissionRole.READER, cal1.getAccessRole());
+		assertNull(cal2.getAccessRole());
+		assertEquals(PermissionRole.WRITER, cal3.getAccessRole());
+		assertEquals(PermissionRole.FREE_BUSY_READER, cal4.getAccessRole());
+
+		assertNotNull(cal0.getDefaultReminders());
+		assertEquals(3, cal0.getDefaultReminders().size());
+		assertEquals(NotificationMethod.EMAIL, cal0.getDefaultReminders().get(0).getMethod());
+		assertEquals(20, cal0.getDefaultReminders().get(0).getMinutes());
+		assertEquals(NotificationMethod.SMS, cal0.getDefaultReminders().get(1).getMethod());
+		assertEquals(15, cal0.getDefaultReminders().get(1).getMinutes());
+		assertEquals(NotificationMethod.POPUP, cal0.getDefaultReminders().get(2).getMethod());
+		assertEquals(10, cal0.getDefaultReminders().get(2).getMinutes());
+		assertNotNull(cal1.getDefaultReminders());
+		assertEquals(0, cal1.getDefaultReminders().size());
+		assertNull(cal2.getDefaultReminders());
+		assertNotNull(cal3.getDefaultReminders());
+		
+		// defaultReminders JSON contains [ {} ] but {} doesn't get instantiated, so size 0.
+		// But this should never occur in a real response.
+		assertEquals(0, cal3.getDefaultReminders().size());
+		
+		assertEquals(0, cal4.getDefaultReminders().size());
+
+		assertNotNull(cal0.getNotificationSettings());
+		assertNotNull(cal0.getNotificationSettings().getNotifications());
+		assertEquals(4, cal0.getNotificationSettings().getNotifications().size());
+		assertEquals(NotificationType.EVENT_CREATION, cal0.getNotificationSettings().getNotifications().get(0).getType());
+		assertEquals(NotificationMethod.EMAIL, cal0.getNotificationSettings().getNotifications().get(0).getMethod());
+		assertEquals(NotificationType.EVENT_CHANGE, cal0.getNotificationSettings().getNotifications().get(1).getType());
+		assertEquals(NotificationMethod.SMS, cal0.getNotificationSettings().getNotifications().get(1).getMethod());
+		assertEquals(NotificationType.EVENT_CANCELLATION, cal0.getNotificationSettings().getNotifications().get(2).getType());
+		assertEquals(NotificationMethod.EMAIL, cal0.getNotificationSettings().getNotifications().get(2).getMethod());
+		assertEquals(NotificationType.EVENT_RESPONSE, cal0.getNotificationSettings().getNotifications().get(3).getType());
+		assertEquals(NotificationMethod.EMAIL, cal0.getNotificationSettings().getNotifications().get(3).getMethod());
+		
+		// notificationSettings JSON contains {} and this time it does get instantiated, but no notifications.  
+		assertNotNull(cal1.getNotificationSettings());
+		assertNull(cal1.getNotificationSettings().getNotifications());
+		
+		assertNull(cal2.getNotificationSettings());
+		
+		assertNotNull(cal3.getNotificationSettings());
+		assertNotNull(cal3.getNotificationSettings().getNotifications());
+		assertEquals(0, cal3.getNotificationSettings().getNotifications().size());
+
+		assertNotNull(cal4.getNotificationSettings());
+		assertNotNull(cal4.getNotificationSettings().getNotifications());
+		// notifications JSON contains [ {} ] but this time it does get instantiated to an empty instance, so size 1.
+		assertEquals(1, cal4.getNotificationSettings().getNotifications().size());
+		assertNotNull(cal4.getNotificationSettings().getNotifications().get(0));
+		assertNull(cal4.getNotificationSettings().getNotifications().get(0).getMethod());
+		assertNull(cal4.getNotificationSettings().getNotifications().get(0).getType());
+
+		assertEquals(true, cal0.isPrimary());
+		assertEquals(false, cal1.isPrimary());
+		assertEquals(false, cal2.isPrimary());
+		assertEquals(false, cal3.isPrimary());
+		assertEquals(false, cal4.isPrimary());
+		
+		assertEquals(false, cal0.isDeleted());
+		assertEquals(false, cal1.isDeleted());
+		assertEquals(false, cal2.isDeleted());
+		assertEquals(true, cal3.isDeleted());
+		assertEquals(true, cal4.isDeleted());
+	}
+}

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_CalendarUrlTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_CalendarUrlTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.junit.Test;
+import org.springframework.social.google.api.AbstractGoogleApiTest;
+
+public class CalendarTemplate_CalendarUrlTests extends AbstractGoogleApiTest {
+
+	@Test
+	public void listCalendars_with_minAccessRole_freeBusyReader() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList?minAccessRole=freeBusyReader"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_calendars"), APPLICATION_JSON));
+
+		CalendarPage calPage = google.calendarOperations().calendarListQuery().minAccessRole(PermissionRole.FREE_BUSY_READER).getPage();
+
+		assertNotNull(calPage);
+	}
+
+	@Test
+	public void listCalendars_with_minAccessRole_owner() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList?minAccessRole=owner"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_calendars"), APPLICATION_JSON));
+
+		CalendarPage calPage = google.calendarOperations().calendarListQuery().minAccessRole(PermissionRole.OWNER).getPage();
+
+		assertNotNull(calPage);
+	}
+
+	@Test
+	public void listCalendars_with_minAccessRole_reader() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList?minAccessRole=reader"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_calendars"), APPLICATION_JSON));
+
+		CalendarPage calPage = google.calendarOperations().calendarListQuery().minAccessRole(PermissionRole.READER).getPage();
+
+		assertNotNull(calPage);
+	}
+
+	@Test
+	public void listCalendars_with_minAccessRole_writer() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList?minAccessRole=writer"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_calendars"), APPLICATION_JSON));
+
+		CalendarPage calPage = google.calendarOperations().calendarListQuery().minAccessRole(PermissionRole.WRITER).getPage();
+
+		assertNotNull(calPage);
+	}
+
+	@Test
+	public void listCalendars_with_showDeleted_true() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList?showDeleted=true"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_calendars"), APPLICATION_JSON));
+
+		CalendarPage calPage = google.calendarOperations().calendarListQuery().showDeleted(true).getPage();
+
+		assertNotNull(calPage);
+	}
+
+	@Test
+	public void listCalendars_with_showDeleted_false() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_calendars"), APPLICATION_JSON));
+
+		CalendarPage calPage = google.calendarOperations().calendarListQuery().showDeleted(false).getPage();
+
+		assertNotNull(calPage);
+	}
+
+	@Test
+	public void listCalendars_with_showHidden_true() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList?showHidden=true"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_calendars"), APPLICATION_JSON));
+
+		CalendarPage calPage = google.calendarOperations().calendarListQuery().showHidden(true).getPage();
+
+		assertNotNull(calPage);
+	}
+
+	@Test
+	public void listCalendars_with_showHidden_false() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_calendars"), APPLICATION_JSON));
+
+		CalendarPage calPage = google.calendarOperations().calendarListQuery().showHidden(false).getPage();
+
+		assertNotNull(calPage);
+	}
+
+	@Test
+	public void getCalendar_primary() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList/primary"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_get_calendar_primary"), APPLICATION_JSON));
+
+		Calendar cal = google.calendarOperations().getCalendar("primary");
+
+		assertNotNull(cal);
+		// NB queried for "primary" but actually get back the real ID.
+		assertEquals("martxw@gmail.com", cal.getId());
+		assertEquals("martxw@gmail.com", cal.getSummary());
+		assertEquals(true, cal.isPrimary());
+	}
+
+	@Test
+	public void getCalendar_escaped() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_get_calendar_primary"), APPLICATION_JSON));
+
+		Calendar cal = google.calendarOperations().getCalendar("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?");
+
+		assertNotNull(cal);
+		// NB queried for "primary" but actually get back the real ID.
+		assertEquals("martxw@gmail.com", cal.getId());
+		assertEquals("martxw@gmail.com", cal.getSummary());
+		assertEquals(true, cal.isPrimary());
+	}
+}

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_EventJsonTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_EventJsonTests.java
@@ -1,0 +1,1155 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.social.google.api.AbstractGoogleApiTest;
+import org.springframework.social.google.api.calendar.Event.Attendee;
+import org.springframework.social.google.api.calendar.Event.Creator;
+import org.springframework.social.google.api.calendar.Event.DateTimeTimezone;
+import org.springframework.social.google.api.calendar.Event.ExtendedProperties;
+import org.springframework.social.google.api.calendar.Event.Gadget;
+import org.springframework.social.google.api.calendar.Event.Organizer;
+import org.springframework.social.google.api.calendar.Event.ReminderOverride;
+import org.springframework.social.google.api.calendar.Event.Reminders;
+import org.springframework.social.google.api.calendar.Event.Source;
+
+/**
+ * Tests to verify that the JSON responses are correctly parsed for each of the requests.
+ * @author Martin Wink
+ */
+public class CalendarTemplate_EventJsonTests extends AbstractGoogleApiTest {
+
+	@Test
+	public void listEvents() {
+
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"1415499182398000\"", eventPage.getEtag());
+	}
+
+	@Test
+	public void listEvents_missing() {
+
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events_missing"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"0001\"", eventPage.getEtag());
+		assertNull(eventPage.getItems());
+	}
+
+	@Test
+	public void listEvents_empty() {
+
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events_empty"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"0001\"", eventPage.getEtag());
+		assertNotNull(eventPage.getItems());
+		assertEquals(0, eventPage.getItems().size());
+	}
+
+	@Test
+	public void listEvents_values_1() {
+// Fully populate the JSON first.
+		
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events_values_1"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"0001\"", eventPage.getEtag());
+		assertNotNull(eventPage.getItems());
+		assertEquals(1, eventPage.getItems().size());
+
+		Event event = eventPage.getItems().get(0);
+		assertNotNull(event);
+		assertEquals("\"etag1\"", event.getEtag());
+		
+		assertEquals("string1", event.getId());
+		assertEquals(EventStatus.CONFIRMED, event.getStatus());
+		assertEquals("string3", event.getHtmlLink());
+		assertEquals(DateUtils.makeDate(2000, 1, 1), event.getCreated());
+		assertEquals(DateUtils.makeDate(2000, 1, 1), event.getUpdated());
+
+		assertEquals("string4", event.getSummary());
+		assertEquals("string5", event.getDescription());
+		assertEquals("string6", event.getLocation());
+		assertEquals("string7", event.getColorId());
+		assertEquals("string17", event.getRecurringEventId());
+		assertEquals(Transparency.OPAQUE, event.getTransparency());
+		assertEquals(Visibility.DEFAULT, event.getVisibility());
+		assertEquals("string21", event.getiCalUID());
+		assertEquals(1, event.getSequence().intValue());
+		assertEquals("string29", event.getHangoutLink());
+
+		assertEquals(true, event.isEndTimeUnspecified());
+		assertEquals(true, event.isAttendeesOmitted());
+		assertEquals(true, event.isAnyoneCanAddSelf());
+		assertEquals(true, event.isGuestsCanInviteOthers());
+		assertEquals(true, event.isGuestsCanModify());
+		assertEquals(true, event.isGuestsCanSeeOtherGuests());
+		assertEquals(true, event.isPrivateCopy());
+		assertEquals(true, event.isLocked());
+
+		{
+			Creator creator = event.getCreator();
+			assertNotNull(creator);
+			assertEquals("string8", creator.getId());
+			assertEquals("string9", creator.getEmail());
+			assertEquals("string10", creator.getDisplayName());
+			assertEquals(true, creator.isSelf());
+		}
+
+		{
+			Organizer organizer = event.getOrganizer();
+			assertNotNull(organizer);
+			assertEquals("string11", organizer.getId());
+			assertEquals("string12", organizer.getEmail());
+			assertEquals("string13", organizer.getDisplayName());
+			assertEquals(true, organizer.isSelf());
+		}
+
+		{
+			DateTimeTimezone dtz = event.getStart();
+			assertNotNull(dtz);
+			assertEquals(DateUtils.makeDate(2000, 1, 1), dtz.getDate());
+			assertEquals(DateUtils.makeDate(2000, 1, 1), dtz.getDateTime());
+			assertEquals(DateUtils.TEST_TIMEZONE, dtz.getTimeZone());
+		}
+
+		{
+			DateTimeTimezone dtz = event.getEnd();
+			assertNotNull(dtz);
+			assertEquals(DateUtils.makeDate(2000, 1, 1), dtz.getDate());
+			assertEquals(DateUtils.makeDate(2000, 1, 1), dtz.getDateTime());
+			assertEquals(DateUtils.TEST_TIMEZONE, dtz.getTimeZone());
+		}
+
+		{
+			List<String> recurrence = event.getRecurrence();
+			assertNotNull(recurrence);
+			assertEquals(1, recurrence.size());
+			assertEquals("string16", recurrence.get(0));
+		}
+		
+		{
+			DateTimeTimezone dtz = event.getOriginalStartTime();
+			assertNotNull(dtz);
+			assertEquals(DateUtils.makeDate(2000, 1, 1), dtz.getDate());
+			assertEquals(DateUtils.makeDate(2000, 1, 1), dtz.getDateTime());
+			assertEquals(DateUtils.TEST_TIMEZONE, dtz.getTimeZone());
+		}
+
+		{
+			List<Attendee> attendees = event.getAttendees();
+			assertNotNull(attendees);
+			assertEquals(1, attendees.size());
+
+			Attendee att = attendees.get(0);
+			assertEquals("string22", att.getId());
+			assertEquals("string23", att.getEmail());
+			assertEquals("string24", att.getDisplayName());
+			assertEquals(true, att.isOrganizer());
+			assertEquals(true, att.isSelf());
+			assertEquals(true, att.isResource());
+			assertEquals(true, att.isOptional());
+			assertEquals(AttendeeStatus.NEEDS_ACTION, att.getResponseStatus());
+			assertEquals("string26", att.getComment());
+			assertEquals(1, att.getAdditionalGuests().intValue());
+		}
+		
+		{
+			ExtendedProperties extendedProperties = event.getExtendedProperties();
+			assertNotNull(extendedProperties);
+			{
+				Map<String, String> m = extendedProperties.getPrivateProperties();
+				assertNotNull(m);
+				assertEquals(1, m.size());
+				assertEquals("string27", m.get("(key1)"));
+			}
+			{
+				Map<String, String> m = extendedProperties.getSharedProperties();
+				assertNotNull(m);
+				assertEquals(1, m.size());
+				assertEquals("string28", m.get("(key2)"));
+			}
+		}
+		
+		{
+			Gadget gadget = event.getGadget();
+			assertNotNull(gadget);
+			assertEquals("string30", gadget.getType());
+			assertEquals("string31", gadget.getTitle());
+			assertEquals("string32", gadget.getLink());
+			assertEquals("string33", gadget.getIconLink());
+			assertEquals(11, gadget.getWidth().intValue());
+			assertEquals(11, gadget.getHeight().intValue());
+			assertEquals(DisplayMode.ICON, gadget.getDisplay());
+			
+			Map<String, String> m = gadget.getPreferences();
+			assertNotNull(m);
+			assertEquals(1, m.size());
+			assertEquals("string35", m.get("(key3)"));
+		}
+		
+		{
+			Reminders reminders = event.getReminders();
+			assertNotNull(reminders);
+			assertEquals(true, reminders.isUseDefault());
+
+			List<ReminderOverride> overrides = reminders.getOverrides();
+			assertNotNull(overrides);
+			assertEquals(1, overrides.size());
+			ReminderOverride ro = overrides.get(0);
+			assertNotNull(ro);
+			assertEquals(NotificationMethod.EMAIL, ro.getMethod());
+			assertEquals(12, ro.getMinutes().intValue());
+		}
+
+		{
+			Source source = event.getSource();
+			assertNotNull(source);
+			assertEquals("string37", source.getUrl());
+			assertEquals("string38", source.getTitle());
+		}
+	}
+
+	@Test
+	public void listEvents_values_2() {
+// Swap the values for the next in sequence - booleans swap, enums on to next, strings to empty, numbers to zero.
+		
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events_values_2"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"0001\"", eventPage.getEtag());
+		assertNotNull(eventPage.getItems());
+		assertEquals(1, eventPage.getItems().size());
+
+		Event event = eventPage.getItems().get(0);
+		assertNotNull(event);
+		assertEquals("\"etag1\"", event.getEtag());
+		
+		assertEquals("", event.getId());
+		assertEquals(EventStatus.TENTATIVE, event.getStatus());
+		assertEquals("", event.getHtmlLink());
+		assertEquals(DateUtils.makeDate(1970, 1, 1), event.getCreated());
+		assertEquals(DateUtils.makeDate(1970, 1, 1), event.getUpdated());
+
+		assertEquals("", event.getSummary());
+		assertEquals("", event.getDescription());
+		assertEquals("", event.getLocation());
+		assertEquals("", event.getColorId());
+		assertEquals("", event.getRecurringEventId());
+		assertEquals(Transparency.TRANSPARENT, event.getTransparency());
+		assertEquals(Visibility.PUBLIC, event.getVisibility());
+		assertEquals("", event.getiCalUID());
+		assertEquals(0, event.getSequence().intValue());
+		assertEquals("", event.getHangoutLink());
+
+		assertEquals(false, event.isEndTimeUnspecified());
+		assertEquals(false, event.isAttendeesOmitted());
+		assertEquals(false, event.isAnyoneCanAddSelf());
+		assertEquals(false, event.isGuestsCanInviteOthers());
+		assertEquals(false, event.isGuestsCanModify());
+		assertEquals(false, event.isGuestsCanSeeOtherGuests());
+		assertEquals(false, event.isPrivateCopy());
+		assertEquals(false, event.isLocked());
+
+		{
+			Creator creator = event.getCreator();
+			assertNotNull(creator);
+			assertEquals("", creator.getId());
+			assertEquals("", creator.getEmail());
+			assertEquals("", creator.getDisplayName());
+			assertEquals(false, creator.isSelf());
+		}
+
+		{
+			Organizer organizer = event.getOrganizer();
+			assertNotNull(organizer);
+			assertEquals("", organizer.getId());
+			assertEquals("", organizer.getEmail());
+			assertEquals("", organizer.getDisplayName());
+			assertEquals(false, organizer.isSelf());
+		}
+
+		{
+			DateTimeTimezone dtz = event.getStart();
+			assertNotNull(dtz);
+			assertEquals(DateUtils.makeDate(1970, 1, 1), dtz.getDate());
+			assertEquals(DateUtils.makeDate(1970, 1, 1), dtz.getDateTime());
+			assertEquals(DateUtils.TEST_TIMEZONE, dtz.getTimeZone());
+		}
+
+		{
+			DateTimeTimezone dtz = event.getEnd();
+			assertNotNull(dtz);
+			assertEquals(DateUtils.makeDate(1970, 1, 1), dtz.getDate());
+			assertEquals(DateUtils.makeDate(1970, 1, 1), dtz.getDateTime());
+			assertEquals(DateUtils.TEST_TIMEZONE, dtz.getTimeZone());
+		}
+
+		{
+			List<String> recurrence = event.getRecurrence();
+			assertNotNull(recurrence);
+			assertEquals(1, recurrence.size());
+			assertEquals("", recurrence.get(0));
+		}
+		
+		{
+			DateTimeTimezone dtz = event.getOriginalStartTime();
+			assertNotNull(dtz);
+			assertEquals(DateUtils.makeDate(1970, 1, 1), dtz.getDate());
+			assertEquals(DateUtils.makeDate(1970, 1, 1), dtz.getDateTime());
+			assertEquals(DateUtils.TEST_TIMEZONE, dtz.getTimeZone());
+		}
+
+		{
+			List<Attendee> attendees = event.getAttendees();
+			assertNotNull(attendees);
+			assertEquals(1, attendees.size());
+
+			Attendee att = attendees.get(0);
+			assertEquals("", att.getId());
+			assertEquals("", att.getEmail());
+			assertEquals("", att.getDisplayName());
+			assertEquals(false, att.isOrganizer());
+			assertEquals(false, att.isSelf());
+			assertEquals(false, att.isResource());
+			assertEquals(false, att.isOptional());
+			assertEquals(AttendeeStatus.DECLINED, att.getResponseStatus());
+			assertEquals("", att.getComment());
+			assertEquals(0, att.getAdditionalGuests().intValue());
+		}
+		
+		{
+			ExtendedProperties extendedProperties = event.getExtendedProperties();
+			assertNotNull(extendedProperties);
+			{
+				Map<String, String> m = extendedProperties.getPrivateProperties();
+				assertNotNull(m);
+				assertEquals(1, m.size());
+				assertEquals("", m.get("(key1)"));
+			}
+			{
+				Map<String, String> m = extendedProperties.getSharedProperties();
+				assertNotNull(m);
+				assertEquals(1, m.size());
+				assertEquals("", m.get("(key2)"));
+			}
+		}
+		
+		{
+			Gadget gadget = event.getGadget();
+			assertNotNull(gadget);
+			assertEquals("", gadget.getType());
+			assertEquals("", gadget.getTitle());
+			assertEquals("", gadget.getLink());
+			assertEquals("", gadget.getIconLink());
+			assertEquals(0, gadget.getWidth().intValue());
+			assertEquals(0, gadget.getHeight().intValue());
+			assertEquals(DisplayMode.CHIP, gadget.getDisplay());
+			
+			Map<String, String> m = gadget.getPreferences();
+			assertNotNull(m);
+			assertEquals(1, m.size());
+			assertEquals("", m.get("(key3)"));
+		}
+		
+		{
+			Reminders reminders = event.getReminders();
+			assertNotNull(reminders);
+			assertEquals(false, reminders.isUseDefault());
+
+			List<ReminderOverride> overrides = reminders.getOverrides();
+			assertNotNull(overrides);
+			assertEquals(1, overrides.size());
+			ReminderOverride ro = overrides.get(0);
+			assertNotNull(ro);
+			assertEquals(NotificationMethod.SMS, ro.getMethod());
+			assertEquals(0, ro.getMinutes().intValue());
+		}
+
+		{
+			Source source = event.getSource();
+			assertNotNull(source);
+			assertEquals("", source.getUrl());
+			assertEquals("", source.getTitle());
+		}
+	}
+
+	@Test
+	public void listEvents_values_3() {
+// Swap the values for the next in sequence - booleans swap, enums on to next, strings to empty, numbers to zero.
+		
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events_values_3"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"0001\"", eventPage.getEtag());
+		assertNotNull(eventPage.getItems());
+		assertEquals(1, eventPage.getItems().size());
+
+		Event event = eventPage.getItems().get(0);
+		assertNotNull(event);
+		assertEquals("\"etag1\"", event.getEtag());
+		
+		assertEquals("", event.getId());
+		assertEquals(EventStatus.CANCELLED, event.getStatus());
+		assertNull(event.getHtmlLink());
+		assertNull(event.getCreated());
+		assertNull(event.getUpdated());
+
+		assertNull(event.getSummary());
+		assertNull(event.getDescription());
+		assertNull(event.getLocation());
+		assertNull(event.getColorId());
+		assertNull(event.getRecurringEventId());
+		assertNull(event.getTransparency());
+		assertEquals(Visibility.PRIVATE, event.getVisibility());
+		assertNull(event.getiCalUID());
+		assertNull(event.getSequence());
+		assertNull(event.getHangoutLink());
+
+		assertNull(event.isEndTimeUnspecified());
+		assertNull(event.isAttendeesOmitted());
+		assertNull(event.isAnyoneCanAddSelf());
+		assertTrue(event.isGuestsCanInviteOthers());
+		assertNull(event.isGuestsCanModify());
+		assertTrue(event.isGuestsCanSeeOtherGuests());
+		assertNull(event.isPrivateCopy());
+		assertNull(event.isLocked());
+
+		{
+			Creator creator = event.getCreator();
+			assertNotNull(creator);
+			assertNull(creator.getId());
+			assertNull(creator.getEmail());
+			assertNull(creator.getDisplayName());
+			assertNull(creator.isSelf());
+		}
+
+		{
+			Organizer organizer = event.getOrganizer();
+			assertNotNull(organizer);
+			assertNull(organizer.getId());
+			assertNull(organizer.getEmail());
+			assertNull(organizer.getDisplayName());
+			assertNull(organizer.isSelf());
+		}
+
+		{
+			DateTimeTimezone dtz = event.getStart();
+			assertNotNull(dtz);
+			assertNull(dtz.getDate());
+			assertNull(dtz.getDateTime());
+			assertNull(dtz.getTimeZone());
+		}
+
+		{
+			DateTimeTimezone dtz = event.getEnd();
+			assertNotNull(dtz);
+			assertNull(dtz.getDate());
+			assertNull(dtz.getDateTime());
+			assertNull(dtz.getTimeZone());
+		}
+
+		{
+			List<String> recurrence = event.getRecurrence();
+			assertNotNull(recurrence);
+			assertEquals(0, recurrence.size());
+		}
+		
+		{
+			DateTimeTimezone dtz = event.getOriginalStartTime();
+			assertNotNull(dtz);
+			assertNull(dtz.getDate());
+			assertNull(dtz.getDateTime());
+			assertNull(dtz.getTimeZone());
+		}
+
+		{
+			List<Attendee> attendees = event.getAttendees();
+			assertNotNull(attendees);
+			assertEquals(1, attendees.size());
+
+			Attendee att = attendees.get(0);
+			assertNull(att.getId());
+			assertNull(att.getEmail());
+			assertNull(att.getDisplayName());
+			assertNull(att.isOrganizer());
+			assertNull(att.isSelf());
+			assertNull(att.isResource());
+			assertNull(att.isOptional());
+			assertEquals(AttendeeStatus.TENTATIVE, att.getResponseStatus());
+			assertNull(att.getComment());
+			assertNull(att.getAdditionalGuests());
+		}
+		
+		{
+			ExtendedProperties extendedProperties = event.getExtendedProperties();
+			assertNotNull(extendedProperties);
+			{
+				Map<String, String> m = extendedProperties.getPrivateProperties();
+				assertNotNull(m);
+				assertEquals(0, m.size());
+			}
+			{
+				Map<String, String> m = extendedProperties.getSharedProperties();
+				assertNotNull(m);
+				assertEquals(0, m.size());
+			}
+		}
+		
+		{
+			Gadget gadget = event.getGadget();
+			assertNotNull(gadget);
+			assertNull(gadget.getType());
+			assertNull(gadget.getTitle());
+			assertNull(gadget.getLink());
+			assertNull(gadget.getIconLink());
+			assertNull(gadget.getWidth());
+			assertNull(gadget.getHeight());
+			assertNull(gadget.getDisplay());
+			
+			Map<String, String> m = gadget.getPreferences();
+			assertNotNull(m);
+			assertEquals(0, m.size());
+		}
+		
+		{
+			Reminders reminders = event.getReminders();
+			assertNotNull(reminders);
+			assertNull(reminders.isUseDefault());
+
+			List<ReminderOverride> overrides = reminders.getOverrides();
+			assertNotNull(overrides);
+			assertEquals(1, overrides.size());
+			ReminderOverride ro = overrides.get(0);
+			assertNotNull(ro);
+			assertEquals(NotificationMethod.POPUP, ro.getMethod());
+			assertNull(ro.getMinutes());
+		}
+
+		{
+			Source source = event.getSource();
+			assertNotNull(source);
+			assertNull(source.getUrl());
+			assertNull(source.getTitle());
+		}
+	}
+
+	@Test
+	public void listEvents_values_4() {
+// Swap the values for the next in sequence - booleans swap, enums on to next, strings to empty, numbers to zero.
+		
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events_values_4"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"0001\"", eventPage.getEtag());
+		assertNotNull(eventPage.getItems());
+		assertEquals(1, eventPage.getItems().size());
+
+		Event event = eventPage.getItems().get(0);
+		assertNotNull(event);
+		assertEquals("\"etag1\"", event.getEtag());
+		
+		assertEquals("", event.getId());
+		assertNull(event.getStatus());
+		assertNull(event.getHtmlLink());
+		assertNull(event.getCreated());
+		assertNull(event.getUpdated());
+
+		assertNull(event.getSummary());
+		assertNull(event.getDescription());
+		assertNull(event.getLocation());
+		assertNull(event.getColorId());
+		assertNull(event.getRecurringEventId());
+		assertNull(event.getTransparency());
+		assertEquals(Visibility.CONFIDENTIAL, event.getVisibility());
+		assertNull(event.getiCalUID());
+		assertNull(event.getSequence());
+		assertNull(event.getHangoutLink());
+
+		assertNull(event.isEndTimeUnspecified());
+		assertNull(event.isAttendeesOmitted());
+		assertNull(event.isAnyoneCanAddSelf());
+		assertTrue(event.isGuestsCanInviteOthers());
+		assertNull(event.isGuestsCanModify());
+		assertTrue(event.isGuestsCanSeeOtherGuests());
+		assertNull(event.isPrivateCopy());
+		assertNull(event.isLocked());
+
+		{
+			Creator creator = event.getCreator();
+			assertNull(creator);
+		}
+
+		{
+			Organizer organizer = event.getOrganizer();
+			assertNull(organizer);
+		}
+
+		{
+			DateTimeTimezone dtz = event.getStart();
+			assertNotNull(dtz);
+			assertNull(dtz.getDate());
+			assertNull(dtz.getDateTime());
+			assertNull(dtz.getTimeZone());
+		}
+
+		{
+			DateTimeTimezone dtz = event.getEnd();
+			assertNotNull(dtz);
+			assertNull(dtz.getDate());
+			assertNull(dtz.getDateTime());
+			assertNull(dtz.getTimeZone());
+		}
+
+		{
+			List<String> recurrence = event.getRecurrence();
+			assertNull(recurrence);
+		}
+		
+		{
+			DateTimeTimezone dtz = event.getOriginalStartTime();
+			assertNotNull(dtz);
+			assertNull(dtz.getDate());
+			assertNull(dtz.getDateTime());
+			assertNull(dtz.getTimeZone());
+		}
+
+		{
+			List<Attendee> attendees = event.getAttendees();
+			assertNotNull(attendees);
+			assertEquals(1, attendees.size());
+
+			Attendee att = attendees.get(0);
+			assertNull(att.getId());
+			assertNull(att.getEmail());
+			assertNull(att.getDisplayName());
+			assertNull(att.isOrganizer());
+			assertNull(att.isSelf());
+			assertNull(att.isResource());
+			assertNull(att.isOptional());
+			assertEquals(AttendeeStatus.ACCEPTED, att.getResponseStatus());
+			assertNull(att.getComment());
+			assertNull(att.getAdditionalGuests());
+		}
+		
+		{
+			ExtendedProperties extendedProperties = event.getExtendedProperties();
+			assertNotNull(extendedProperties);
+			{
+				Map<String, String> m = extendedProperties.getPrivateProperties();
+				assertNull(m);
+			}
+			{
+				Map<String, String> m = extendedProperties.getSharedProperties();
+				assertNull(m);
+			}
+		}
+		
+		{
+			Gadget gadget = event.getGadget();
+			assertNotNull(gadget);
+			assertNull(gadget.getType());
+			assertNull(gadget.getTitle());
+			assertNull(gadget.getLink());
+			assertNull(gadget.getIconLink());
+			assertNull(gadget.getWidth());
+			assertNull(gadget.getHeight());
+			assertNull(gadget.getDisplay());
+			
+			Map<String, String> m = gadget.getPreferences();
+			assertNull(m);
+		}
+		
+		{
+			Reminders reminders = event.getReminders();
+			assertNotNull(reminders);
+			assertNull(reminders.isUseDefault());
+
+			List<ReminderOverride> overrides = reminders.getOverrides();
+			assertNotNull(overrides);
+			assertEquals(1, overrides.size());
+			ReminderOverride ro = overrides.get(0);
+			assertNotNull(ro);
+			assertNull(ro.getMethod());
+			assertNull(ro.getMinutes());
+		}
+
+		{
+			Source source = event.getSource();
+			assertNull(source);
+		}
+	}
+
+	@Test
+	public void listEvents_values_5() {
+// Swap the values for the next in sequence - booleans swap, enums on to next, strings to empty, numbers to zero.
+		
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events_values_5"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"0001\"", eventPage.getEtag());
+		assertNotNull(eventPage.getItems());
+		assertEquals(1, eventPage.getItems().size());
+
+		Event event = eventPage.getItems().get(0);
+		assertNotNull(event);
+		assertEquals("\"etag1\"", event.getEtag());
+		
+		assertEquals("", event.getId());
+		assertNull(event.getStatus());
+		assertNull(event.getHtmlLink());
+		assertNull(event.getCreated());
+		assertNull(event.getUpdated());
+
+		assertNull(event.getSummary());
+		assertNull(event.getDescription());
+		assertNull(event.getLocation());
+		assertNull(event.getColorId());
+		assertNull(event.getRecurringEventId());
+		assertNull(event.getTransparency());
+		assertNull(event.getVisibility());
+		assertNull(event.getiCalUID());
+		assertNull(event.getSequence());
+		assertNull(event.getHangoutLink());
+
+		assertNull(event.isEndTimeUnspecified());
+		assertNull(event.isAttendeesOmitted());
+		assertNull(event.isAnyoneCanAddSelf());
+		assertTrue(event.isGuestsCanInviteOthers());
+		assertNull(event.isGuestsCanModify());
+		assertTrue(event.isGuestsCanSeeOtherGuests());
+		assertNull(event.isPrivateCopy());
+		assertNull(event.isLocked());
+
+		{
+			Creator creator = event.getCreator();
+			assertNull(creator);
+		}
+
+		{
+			Organizer organizer = event.getOrganizer();
+			assertNull(organizer);
+		}
+
+		{
+			DateTimeTimezone dtz = event.getStart();
+			assertNull(dtz);
+		}
+
+		{
+			DateTimeTimezone dtz = event.getEnd();
+			assertNull(dtz);
+		}
+
+		{
+			List<String> recurrence = event.getRecurrence();
+			assertNull(recurrence);
+		}
+		
+		{
+			DateTimeTimezone dtz = event.getOriginalStartTime();
+			assertNull(dtz);
+		}
+
+		{
+			List<Attendee> attendees = event.getAttendees();
+			assertNotNull(attendees);
+			assertEquals(1, attendees.size());
+
+			Attendee att = attendees.get(0);
+			assertNull(att.getId());
+			assertNull(att.getEmail());
+			assertNull(att.getDisplayName());
+			assertNull(att.isOrganizer());
+			assertNull(att.isSelf());
+			assertNull(att.isResource());
+			assertNull(att.isOptional());
+			assertNull(att.getResponseStatus());
+			assertNull(att.getComment());
+			assertNull(att.getAdditionalGuests());
+		}
+		
+		{
+			ExtendedProperties extendedProperties = event.getExtendedProperties();
+			assertNull(extendedProperties);
+		}
+		
+		{
+			Gadget gadget = event.getGadget();
+			assertNull(gadget);
+		}
+		
+		{
+			Reminders reminders = event.getReminders();
+			assertNotNull(reminders);
+			assertNull(reminders.isUseDefault());
+
+			List<ReminderOverride> overrides = reminders.getOverrides();
+			assertNotNull(overrides);
+			assertEquals(0, overrides.size());
+		}
+
+		{
+			Source source = event.getSource();
+			assertNull(source);
+		}
+	}
+
+	@Test
+	public void listEvents_values_6() {
+// Swap the values for the next in sequence - booleans swap, enums on to next, strings to empty, numbers to zero.
+		
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events_values_6"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"0001\"", eventPage.getEtag());
+		assertNotNull(eventPage.getItems());
+		assertEquals(1, eventPage.getItems().size());
+
+		Event event = eventPage.getItems().get(0);
+		assertNotNull(event);
+		assertEquals("\"etag1\"", event.getEtag());
+		
+		assertEquals("", event.getId());
+		assertNull(event.getStatus());
+		assertNull(event.getHtmlLink());
+		assertNull(event.getCreated());
+		assertNull(event.getUpdated());
+
+		assertNull(event.getSummary());
+		assertNull(event.getDescription());
+		assertNull(event.getLocation());
+		assertNull(event.getColorId());
+		assertNull(event.getRecurringEventId());
+		assertNull(event.getTransparency());
+		assertNull(event.getVisibility());
+		assertNull(event.getiCalUID());
+		assertNull(event.getSequence());
+		assertNull(event.getHangoutLink());
+
+		assertNull(event.isEndTimeUnspecified());
+		assertNull(event.isAttendeesOmitted());
+		assertNull(event.isAnyoneCanAddSelf());
+		assertTrue(event.isGuestsCanInviteOthers());
+		assertNull(event.isGuestsCanModify());
+		assertTrue(event.isGuestsCanSeeOtherGuests());
+		assertNull(event.isPrivateCopy());
+		assertNull(event.isLocked());
+
+		{
+			Creator creator = event.getCreator();
+			assertNull(creator);
+		}
+
+		{
+			Organizer organizer = event.getOrganizer();
+			assertNull(organizer);
+		}
+
+		{
+			DateTimeTimezone dtz = event.getStart();
+			assertNull(dtz);
+		}
+
+		{
+			DateTimeTimezone dtz = event.getEnd();
+			assertNull(dtz);
+		}
+
+		{
+			List<String> recurrence = event.getRecurrence();
+			assertNull(recurrence);
+		}
+		
+		{
+			DateTimeTimezone dtz = event.getOriginalStartTime();
+			assertNull(dtz);
+		}
+
+		{
+			List<Attendee> attendees = event.getAttendees();
+			assertNotNull(attendees);
+			assertEquals(0, attendees.size());
+		}
+		
+		{
+			ExtendedProperties extendedProperties = event.getExtendedProperties();
+			assertNull(extendedProperties);
+		}
+		
+		{
+			Gadget gadget = event.getGadget();
+			assertNull(gadget);
+		}
+		
+		{
+			Reminders reminders = event.getReminders();
+			assertNotNull(reminders);
+			assertNull(reminders.isUseDefault());
+
+			List<ReminderOverride> overrides = reminders.getOverrides();
+			assertNull(overrides);
+		}
+
+		{
+			Source source = event.getSource();
+			assertNull(source);
+		}
+	}
+
+	@Test
+	public void listEvents_values_7() {
+// Swap the values for the next in sequence - booleans swap, enums on to next, strings to empty, numbers to zero.
+		
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+			.andExpect(method(GET))
+			.andRespond(
+					withSuccess(jsonResource("mock_list_events_values_7"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+		assertNull(eventPage.getNextPageToken());
+		assertEquals("\"0001\"", eventPage.getEtag());
+		assertNotNull(eventPage.getItems());
+		assertEquals(1, eventPage.getItems().size());
+
+		Event event = eventPage.getItems().get(0);
+		assertNotNull(event);
+		assertEquals("\"etag1\"", event.getEtag());
+		
+		assertEquals("", event.getId());
+		assertNull(event.getStatus());
+		assertNull(event.getHtmlLink());
+		assertNull(event.getCreated());
+		assertNull(event.getUpdated());
+
+		assertNull(event.getSummary());
+		assertNull(event.getDescription());
+		assertNull(event.getLocation());
+		assertNull(event.getColorId());
+		assertNull(event.getRecurringEventId());
+		assertNull(event.getTransparency());
+		assertNull(event.getVisibility());
+		assertNull(event.getiCalUID());
+		assertNull(event.getSequence());
+		assertNull(event.getHangoutLink());
+
+		assertNull(event.isEndTimeUnspecified());
+		assertNull(event.isAttendeesOmitted());
+		assertNull(event.isAnyoneCanAddSelf());
+		assertTrue(event.isGuestsCanInviteOthers());
+		assertNull(event.isGuestsCanModify());
+		assertTrue(event.isGuestsCanSeeOtherGuests());
+		assertNull(event.isPrivateCopy());
+		assertNull(event.isLocked());
+
+		{
+			Creator creator = event.getCreator();
+			assertNull(creator);
+		}
+
+		{
+			Organizer organizer = event.getOrganizer();
+			assertNull(organizer);
+		}
+
+		{
+			DateTimeTimezone dtz = event.getStart();
+			assertNull(dtz);
+		}
+
+		{
+			DateTimeTimezone dtz = event.getEnd();
+			assertNull(dtz);
+		}
+
+		{
+			List<String> recurrence = event.getRecurrence();
+			assertNull(recurrence);
+		}
+		
+		{
+			DateTimeTimezone dtz = event.getOriginalStartTime();
+			assertNull(dtz);
+		}
+
+		{
+			List<Attendee> attendees = event.getAttendees();
+			assertNull(attendees);
+		}
+		
+		{
+			ExtendedProperties extendedProperties = event.getExtendedProperties();
+			assertNull(extendedProperties);
+		}
+		
+		{
+			Gadget gadget = event.getGadget();
+			assertNull(gadget);
+		}
+		
+		{
+			Reminders reminders = event.getReminders();
+			assertNull(reminders);
+		}
+
+		{
+			Source source = event.getSource();
+			assertNull(source);
+		}
+	}
+
+	@Test
+	public void getEvent_primary() {
+
+		String id = "_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g6oo4agph751kah9o84r46ghg64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g891jeh9o88qk6cpk612k6c1k6ss3idi488o36h1i8p1k6hhp6oog";
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events/_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g6oo4agph751kah9o84r46ghg64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g891jeh9o88qk6cpk612k6c1k6ss3idi488o36h1i8p1k6hhp6oog"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_get_event"), APPLICATION_JSON));
+
+		Event event = google.calendarOperations().getEvent(CalendarOperations.PRIMARY_CALENDAR_ID, id);
+
+		assertNotNull(event);
+		assertEquals(id, event.getId());
+		assertEquals("Wearable Tech Show", event.getSummary());
+	}
+
+	@Test
+	public void quickAddEvent() {
+
+		// Not testing the actual creation, but check URL.
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events/quickAdd?text=Appointment+at+Somewhere+every+June+3rd+10am-10%3A25am&sendNotifications=true"))
+			.andExpect(method(POST))
+			.andRespond(
+					withSuccess(jsonResource("mock_added_event"), APPLICATION_JSON));
+
+		Event event = google.calendarOperations().quickAddEvent("primary", "Appointment at Somewhere every June 3rd 10am-10:25am", true);
+
+		assertNotNull(event);
+		assertEquals(1, event.getRecurrence().size());
+		assertEquals("RRULE:FREQ=YEARLY;INTERVAL=1", event.getRecurrence().get(0));
+		assertNotNull(event.getStart());
+		assertNotNull(event.getStart().getDateTime());
+		assertNull(event.getStart().getDate());
+	}
+}

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_EventUrlTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_EventUrlTests.java
@@ -1,0 +1,564 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.Test;
+import org.springframework.social.google.api.AbstractGoogleApiTest;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
+
+	private static final TimeZone TEST_TIMEZONE = TimeZone.getTimeZone("GMT");
+	private static Date makeDate(int y, int m, int d) {
+		java.util.Calendar cal = java.util.Calendar.getInstance(TEST_TIMEZONE);
+		cal.setTimeInMillis(0);
+		cal.set(y, m - 1, d);
+		return cal.getTime();
+	}
+	private static final Date TEST_TIME_MAX = makeDate(2014, 1, 1);
+	private static final Date TEST_TIME_MIN = makeDate(2014, 2, 1);
+	private static final Date TEST_UPDATED_MIN = makeDate(2014, 3, 1);
+
+	@Test
+	public void listEvents_primary_no_options() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+	
+	@Test
+	public void listEvents_primary_fromPage() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?pageToken=CigKGnFiOGdnNWZkZDZkNXRwZGNyNW9kNDRhaHBvGAEggICAnbfk_5AUGg0IABIAGNiisr2F9sEC"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				// A typical page token.
+				.fromPage("CigKGnFiOGdnNWZkZDZkNXRwZGNyNW9kNDRhaHBvGAEggICAnbfk_5AUGg0IABIAGNiisr2F9sEC")
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_fromPage_escaping() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?pageToken=abc123_%C2%AC%21%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.fromPage("abc123_¬!£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_alwaysIncludeEmail_true() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?alwaysIncludeEmail=true"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.alwaysIncludeEmail(true)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+	
+	@Test
+	public void listEvents_primary_alwaysIncludeEmail_false() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.alwaysIncludeEmail(false)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+	
+	@Test
+	public void listEvents_primary_iCalUID() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?iCalUID=testiCalUID"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.iCalUID("testiCalUID")
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+	
+	@Test
+	public void listEvents_primary_maxAttendees() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?maxAttendees=11"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.maxAttendees(11)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+	
+	@Test
+	public void listEvents_primary_maxResults() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?maxResults=100"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.maxResultsNumber(100)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_orderBy_START_TIME() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?orderBy=startTime"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.orderBy(OrderBy.START_TIME)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_orderBy_UPDATED() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?orderBy=updated"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.orderBy(OrderBy.UPDATED)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_showDeleted_true() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?showDeleted=true"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.showDeleted(true)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_showDeleted_false() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.showDeleted(false)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_showHiddenInvitations_true() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?showHiddenInvitations=true"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.showHiddenInvitations(true)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_showHiddenInvitations_false() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.showHiddenInvitations(false)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_singleEvents_true() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?singleEvents=true"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.singleEvents(true)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_singleEvents_false() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.singleEvents(false)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_timeMin_Date() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=2014-02-01T00:00:00.000Z"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.timeMin(TEST_TIME_MIN)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_timeMin_YMD() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=2013-02-01T00:00:00.000Z"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.timeMin(2013, 2, 1)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_timeMax_Date() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMax=2014-01-01T00:00:00.000Z"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.timeMax(TEST_TIME_MAX)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_timeMax_YMD() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMax=2013-01-01T00:00:00.000Z"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.timeMax(2013, 1, 1)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_timeZone() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?timeZone=GMT"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.timeZone(TEST_TIMEZONE)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_updatedMin() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?updatedMin=2014-03-01T00:00:00.000Z"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.updatedMin(TEST_UPDATED_MIN)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_primary_combined_options() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?alwaysIncludeEmail=true&orderBy=startTime&timeZone=GMT&pageToken=pretendPageToken&singleEvents=true&showHiddenInvitations=true&maxResults=50&maxAttendees=9&timeMin=2014-02-01T00:00:00.000Z&iCalUID=test-iCalUID&showDeleted=true&timeMax=2014-01-01T00:00:00.000Z&updatedMin=2014-03-01T00:00:00.000Z"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
+				.fromPage("pretendPageToken")
+				.alwaysIncludeEmail(true)
+				.iCalUID("test-iCalUID")
+				.maxAttendees(9)
+				.maxResultsNumber(50)
+				.orderBy(OrderBy.START_TIME)
+				.showDeleted(true)
+				.showHiddenInvitations(true)
+				.singleEvents(true)
+				.timeMax(TEST_TIME_MAX)
+				.timeMin(TEST_TIME_MIN)
+				.timeZone(TEST_TIMEZONE)
+				.updatedMin(TEST_UPDATED_MIN)
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_escape_calendarId() {
+
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F/events"))
+			.andExpect(method(GET))
+			.andRespond(
+				withSuccess(jsonResource("mock_get_event"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.getPage();
+
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void listEvents_escape_pageToken() {
+
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F/events?pageToken=abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F"))
+			.andExpect(method(GET))
+			.andRespond(
+				withSuccess(jsonResource("mock_list_events_empty"), APPLICATION_JSON));
+
+		EventPage eventPage = google.calendarOperations()
+				.eventListQuery("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.fromPage("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.getPage();
+		
+		assertNotNull(eventPage);
+	}
+
+	@Test
+	public void getEvent_primary() {
+
+		String id = "_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g6oo4agph751kah9o84r46ghg64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g891jeh9o88qk6cpk612k6c1k6ss3idi488o36h1i8p1k6hhp6oog";
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events/_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g6oo4agph751kah9o84r46ghg64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g891jeh9o88qk6cpk612k6c1k6ss3idi488o36h1i8p1k6hhp6oog"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_get_event"), APPLICATION_JSON));
+
+		Event event = google.calendarOperations().getEvent(CalendarOperations.PRIMARY_CALENDAR_ID, id);
+
+		assertNotNull(event);
+	}
+
+	@Test
+	public void getEvent_escape_calendarId() {
+
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F/events/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_get_event"), APPLICATION_JSON));
+
+		Event event = google.calendarOperations().getEvent("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?", "abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?");
+
+		assertNotNull(event);
+	}
+
+	@Test
+	public void quickAddEvent() {
+
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events/quickAdd?text=Appointment+at+Somewhere+every+June+3rd+10am-10%3A25am&sendNotifications=true"))
+			.andExpect(method(POST))
+			.andRespond(
+					withSuccess(jsonResource("mock_added_event"), APPLICATION_JSON));
+
+		Event event = google.calendarOperations().quickAddEvent("primary", "Appointment at Somewhere every June 3rd 10am-10:25am", true);
+
+		assertNotNull(event);
+	}
+
+	@Test
+	public void deleteEvent() {
+
+		String id = "_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g6oo4agph751kah9o84r46ghg64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g891jeh9o88qk6cpk612k6c1k6ss3idi488o36h1i8p1k6hhp6oog";
+
+		mockServer
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events/_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g6oo4agph751kah9o84r46ghg64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g891jeh9o88qk6cpk612k6c1k6ss3idi488o36h1i8p1k6hhp6oog?sendNotifications=true"))
+			.andExpect(method(DELETE))
+			.andRespond(
+					withSuccess());
+
+		google.calendarOperations().deleteEvent("primary", id, true);
+	}
+
+	@Test
+	public void updateEvent() throws JsonParseException, JsonMappingException, IOException {
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);	// kind etc not used in Event.
+		Event event = mapper.readValue(jsonResource("mock_added_event").getFile(), Event.class);
+
+		mockServer
+		.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events/onn6d9kbhps6fc47m96auhtkdo?sendNotifications=true"))
+		.andExpect(method(PUT))
+		.andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))	// compatible with because ";charset=UTF-8" is included.
+		.andRespond(
+				withSuccess());
+
+		google.calendarOperations().updateEvent("primary", event, true);
+	}
+}

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/DateTimeDeserializerTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/DateTimeDeserializerTests.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.social.google.api.AbstractGoogleApiTest;
+import org.springframework.social.google.api.calendar.impl.DateTimeDeserializer;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+/**
+ * Tests to verify that the {@link DateTimeDeserializer} works.
+ * @author Martin Wink
+ */
+public class DateTimeDeserializerTests extends AbstractGoogleApiTest {
+	
+	private static final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US);
+	private static String formatDate(Date date) {
+		format.setTimeZone(DateUtils.TEST_TIMEZONE);
+		return format.format(date);
+	}
+
+	private static DeserializationContext deserializationContext = null;
+	private static JsonParser jsonParser;
+	private static DateTimeDeserializer deserializer;
+	
+	@Before
+	public void beforeEachTest() {
+		jsonParser = mock(JsonParser.class);
+		deserializer = new DateTimeDeserializer();
+	}
+
+	@Test
+	public void verifyMakeDate_1970_1_1() {
+		Date d = DateUtils.makeDate(1970, 1, 1);
+		assertEquals(0, d.getTime());
+	}
+
+	@Test
+	public void verifyMakeDate_2012_2_29() {
+		Date d = DateUtils.makeDate(2012, 2, 29);
+		assertEquals(1330473600000L, d.getTime());
+	}
+
+	@Test
+	public void deserialize_empty_is_null() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("");
+
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertNull(result);
+	}
+
+	@Test(expected=JsonParseException.class)
+	public void deserialize_garbage_exception() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("jhgfjkasdg");
+		@SuppressWarnings("unused")
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+	}
+	
+	@Test
+	public void deserialize_1970_01_01T00_00_00_000Z_is_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:00.000Z");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(0, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_00_000_plus_0_is_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:00.000+00:00");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(0, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_00_000_is_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:00.000");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(0, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_00Z_is_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:00Z");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(0, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T01_00_00_TZ_plus_1_is_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T01:00:00+01:00");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(0, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T02_00_00_TZ_plus_2_is_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T02:00:00+02:00");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(0, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_00_is_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:00");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(0, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_01_is_1000_with_millis_Z() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:01.000Z");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1000, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_01_is_1000_without_millis_Z() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:01Z");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1000, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_01_is_1000_with_millis_plus_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:01.000+00:00");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1000, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_01_is_1000_without_millis_plus_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:01+00:00");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1000, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_01_is_1000_with_millis_minus_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:01.000-00:00");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1000, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_01_is_1000_without_millis_minus_0() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:01-00:00");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1000, result.getTime());
+	}
+
+	@Test
+	public void deserialize_1970_01_01T00_00_01246_is_1246() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("1970-01-01T00:00:01.234Z");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1234, result.getTime());
+	}
+
+	@Test
+	public void deserialize_leap_day_2012() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("2012-02-29T00:00:00.000Z");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1330473600000L, result.getTime());
+
+		// Sanity check
+		assertEquals(jsonParser.getValueAsString(), formatDate(result));
+	}
+
+	@Test
+	public void deserialize_20140101_120000001() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("2014-01-01T12:00:00.001Z");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1388577600001L, result.getTime());
+
+		// Sanity check
+		assertEquals(jsonParser.getValueAsString(), formatDate(result));
+	}
+
+	@Test
+	public void deserialize_20140601_101010000() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("2014-06-01T10:10:10.000Z");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1401617410000L, result.getTime());
+
+		// Sanity check
+		assertEquals(jsonParser.getValueAsString(), formatDate(result));
+	}
+
+	@Test
+	public void deserialize_20141231_235959000() throws JsonParseException, IOException {
+		when(jsonParser.getValueAsString()).thenReturn("2014-12-31T23:59:59.000Z");
+		Date result = deserializer.deserialize(jsonParser, deserializationContext);
+		assertEquals(1420070399000L, result.getTime());
+
+		// Sanity check
+		assertEquals(jsonParser.getValueAsString(), formatDate(result));
+	}
+}

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/DateTimeSerializerTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/DateTimeSerializerTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.social.google.api.AbstractGoogleApiTest;
+import org.springframework.social.google.api.calendar.impl.DateTimeSerializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests to verify that the {@link DateTimeSerializer} works.
+ * @author Martin Wink
+ */
+public class DateTimeSerializerTests extends AbstractGoogleApiTest {
+	private static JsonGenerator jgen;
+	private static SerializerProvider provider = null;
+	private static DateTimeSerializer serializer;
+
+	@Before
+	public void beforeEachTest() {
+		jgen = mock(JsonGenerator.class);
+		serializer = new DateTimeSerializer();
+	}
+
+	@Test(expected=NullPointerException.class)
+	public void serialize_null_exception() throws JsonProcessingException, IOException {
+		serializer.serialize(null, jgen, provider);
+	}
+
+	@Test
+	public void serialize_zero() throws JsonProcessingException, IOException {
+		serializer.serialize(new Date(0), jgen, provider);
+		verify(jgen).writeString("1970-01-01T00:00:00.000Z");
+	}
+
+	@Test
+	public void serialize_one_millisecond() throws JsonProcessingException, IOException {
+		serializer.serialize(new Date(1), jgen, provider);
+		verify(jgen).writeString("1970-01-01T00:00:00.001Z");
+	}
+
+	@Test
+	public void serialize_one_second() throws JsonProcessingException, IOException {
+		serializer.serialize(new Date(1000), jgen, provider);
+		verify(jgen).writeString("1970-01-01T00:00:01.000Z");
+	}
+
+	@Test
+	public void serialize_1234() throws JsonProcessingException, IOException {
+		serializer.serialize(new Date(1234), jgen, provider);
+		verify(jgen).writeString("1970-01-01T00:00:01.234Z");
+	}
+
+	@Test
+	public void serialize_leap_day_2012() throws JsonProcessingException, IOException {
+		serializer.serialize(new Date(1330473600000L), jgen, provider);
+		verify(jgen).writeString("2012-02-29T00:00:00.000Z");
+	}
+
+	@Test
+	public void serialize_20140101_120000001() throws JsonProcessingException, IOException {
+		serializer.serialize(new Date(1388577600001L), jgen, provider);
+		verify(jgen).writeString("2014-01-01T12:00:00.001Z");
+	}
+
+	@Test
+	public void serialize_20140601_101010000() throws JsonProcessingException, IOException {
+		serializer.serialize(new Date(1401617410000L), jgen, provider);
+		verify(jgen).writeString("2014-06-01T10:10:10.000Z");
+	}
+
+	@Test
+	public void serialize_20141231_235959000() throws JsonProcessingException, IOException {
+		serializer.serialize(new Date(1420070399000L), jgen, provider);
+		verify(jgen).writeString("2014-12-31T23:59:59.000Z");
+	}
+}

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/DateUtils.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/DateUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import java.util.Date;
+import java.util.TimeZone;
+
+public class DateUtils {
+	private DateUtils() {
+	}
+
+	public static final TimeZone TEST_TIMEZONE = TimeZone.getTimeZone("GMT");
+
+	public static Date makeDate(int year, int month, int day) {
+		java.util.Calendar cal = java.util.Calendar.getInstance(TEST_TIMEZONE);
+		cal.setTimeInMillis(0);
+		cal.set(year, month - 1, day);
+		return cal.getTime();
+	}
+}

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/EventModificationTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/EventModificationTests.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.social.google.api.AbstractGoogleApiTest;
+import org.springframework.social.google.api.calendar.Event.DateTimeTimezone;
+import org.springframework.util.StreamUtils;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Tests to verify that the Event JSON is correctly updated through the Event class.
+ * @author Martin Wink
+ */
+public class EventModificationTests extends AbstractGoogleApiTest {
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+	
+	private File originalFile;
+	private File newFile;
+	private ObjectMapper mapper;
+	private Event event;
+
+	@Before
+	public void createTestData() throws IOException {
+		originalFile = jsonResource("pre_modification_event").getFile();
+		newFile = folder.newFile();
+		mapper = new ObjectMapper();
+		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);	// kind etc not used in Event.
+		mapper.configure(SerializationFeature.INDENT_OUTPUT, true);	// So output matches expected formatting.
+		event = mapper.readValue(originalFile, Event.class);
+	}
+
+	@After
+	public void cleanUp() {
+	}
+
+	private String loadFileToString(File file) throws IOException, FileNotFoundException {
+		return StreamUtils.copyToString(new FileInputStream(file), Charset.defaultCharset());
+	}
+	
+	private String loadJsonResourceToString(String name) throws FileNotFoundException, IOException {
+		return loadFileToString(jsonResource(name).getFile());
+	}
+
+	@Test
+	public void verify_unmodified() throws JsonParseException, JsonMappingException, IOException {
+		mapper.writeValue(newFile, event);
+		assertEquals(loadJsonResourceToString("post_unmodified_event"), loadFileToString(newFile));
+	}
+
+	@Test
+	public void set_null_values() throws JsonParseException, JsonMappingException, IOException {
+		event.setGuestsCanInviteOthers(null);
+		assertEquals(null, event.isGuestsCanInviteOthers());
+
+		event.setGuestsCanSeeOtherGuests(null);
+		assertEquals(null, event.isGuestsCanSeeOtherGuests());
+
+		event.setLocation(null);
+		assertEquals(null, event.getLocation());
+
+		event.setStatus(null);
+		assertEquals(null, event.getStatus());
+
+		event.setSummary(null);
+		assertEquals(null, event.getSummary());
+
+		final DateTimeTimezone start = event.getStart();
+		start.setDate(null);
+		assertNull(start.getDate());
+
+		start.setDateTime(null);
+		assertNull(start.getDateTime());
+
+		start.setTimeZone(null);
+		assertNull(start.getTimeZone());
+
+		final DateTimeTimezone end = event.getEnd();
+		end.setDate(null);
+		assertNull(end.getDate());
+
+		end.setDateTime(null);
+		assertNull(end.getDateTime());
+
+		end.setTimeZone(null);
+		assertNull(end.getTimeZone());
+		
+		event.setRecurrence(null);
+		assertNull(event.getRecurrence());
+
+		mapper.writeValue(newFile, event);
+		assertEquals(loadJsonResourceToString("post_null_values_event"), loadFileToString(newFile));
+	}
+
+	@Test
+	public void set_non_null_values_1() throws JsonParseException, JsonMappingException, IOException {
+		event.setGuestsCanInviteOthers(true);
+		assertEquals(true, event.isGuestsCanInviteOthers());
+
+		event.setGuestsCanSeeOtherGuests(false);
+		assertEquals(false, event.isGuestsCanSeeOtherGuests());
+
+		event.setLocation("Somewhere else");
+		assertEquals("Somewhere else", event.getLocation());
+
+		event.setStatus(EventStatus.CANCELLED);
+		assertEquals(EventStatus.CANCELLED, event.getStatus());
+
+		event.setSummary("New summary");
+		assertEquals("New summary", event.getSummary());
+
+		final DateTimeTimezone start = event.getStart();
+		final Date date1 = DateUtils.makeDate(2014, 11, 27);
+		start.setDate(date1);
+		assertEquals(date1, start.getDate());
+
+		final Date date2 = DateUtils.makeDate(2014, 11, 28);
+		start.setDateTime(date2);
+		assertEquals(date2, start.getDateTime());
+
+		final TimeZone timeZone1 = TimeZone.getTimeZone("UTC");
+		start.setTimeZone(timeZone1);
+		assertEquals(timeZone1, start.getTimeZone());
+
+		final DateTimeTimezone end = event.getEnd();
+		final Date date3 = DateUtils.makeDate(2014, 11, 29);
+		end.setDate(date3);
+		assertEquals(date3, end.getDate());
+
+		final Date date4 = DateUtils.makeDate(2014, 11, 30);
+		end.setDateTime(date4);
+		assertEquals(date4, end.getDateTime());
+
+		final TimeZone timeZone2 = TimeZone.getTimeZone("PST");
+		end.setTimeZone(timeZone2);
+		assertEquals(timeZone2, end.getTimeZone());
+
+		event.setRecurrence(new ArrayList<String>());
+		assertNotNull(event.getRecurrence());
+		assertEquals(0, event.getRecurrence().size());
+
+		mapper.writeValue(newFile, event);
+		assertEquals(loadJsonResourceToString("post_non_null_values_1_event"), loadFileToString(newFile));
+	}
+
+	@Test
+	public void set_non_null_values_2() throws JsonParseException, JsonMappingException, IOException {
+		event.setGuestsCanInviteOthers(false);
+		assertEquals(false, event.isGuestsCanInviteOthers());
+
+		event.setGuestsCanSeeOtherGuests(true);
+		assertEquals(true, event.isGuestsCanSeeOtherGuests());
+
+		event.setLocation("Another place");
+		assertEquals("Another place", event.getLocation());
+
+		event.setStatus(EventStatus.TENTATIVE);
+		assertEquals(EventStatus.TENTATIVE, event.getStatus());
+
+		event.setSummary("Another title");
+		assertEquals("Another title", event.getSummary());
+
+		final DateTimeTimezone start = event.getStart();
+		final Date date1 = DateUtils.makeDate(2013, 11, 27);
+		start.setDate(date1);
+		assertEquals(date1, start.getDate());
+
+		final Date date2 = DateUtils.makeDate(2013, 11, 28);
+		start.setDateTime(date2);
+		assertEquals(date2, start.getDateTime());
+
+		final TimeZone timeZone1 = TimeZone.getTimeZone("CET");
+		start.setTimeZone(timeZone1);
+		assertEquals(timeZone1, start.getTimeZone());
+
+		final DateTimeTimezone end = event.getEnd();
+		final Date date3 = DateUtils.makeDate(2013, 11, 29);
+		end.setDate(date3);
+		assertEquals(date3, end.getDate());
+
+		final Date date4 = DateUtils.makeDate(2013, 11, 30);
+		end.setDateTime(date4);
+		assertEquals(date4, end.getDateTime());
+
+		final TimeZone timeZone2 = TimeZone.getTimeZone("MST");
+		end.setTimeZone(timeZone2);
+		assertEquals(timeZone2, end.getTimeZone());
+
+		final ArrayList<String> list = new ArrayList<String>();
+		list.add("RRULE:FREQ=MONTHLY;INTERVAL=1");
+		list.add("RRULE:FREQ=MONTHLY;INTERVAL=3");
+		event.setRecurrence(list);
+		assertNotNull(event.getRecurrence());
+		assertEquals(2, event.getRecurrence().size());
+
+		mapper.writeValue(newFile, event);
+		assertEquals(loadJsonResourceToString("post_non_null_values_2_event"), loadFileToString(newFile));
+	}
+
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_added_event.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_added_event.json
@@ -1,0 +1,38 @@
+{
+
+ "kind": "calendar#event",
+ "etag": "\"2831656302604000\"",
+ "id": "onn6d9kbhps6fc47m96auhtkdo",
+ "status": "confirmed",
+ "htmlLink": "https://www.google.com/calendar/event?eid=b25uNmQ5a2JocHM2ZmM0N205NmF1aHRrZG9fMjAxNTA2MDNUMDkwMDAwWiBtYXJ0eHdpbmtAbQ",
+ "created": "2014-11-12T21:35:51.000Z",
+ "updated": "2014-11-12T21:35:51.302Z",
+ "summary": "Appointment at Somewhere",
+ "location": "Somewhere ",
+ "creator": {
+  "email": "martxw@gmail.com",
+  "displayName": "Martin Wink",
+  "self": true
+ },
+ "organizer": {
+  "email": "martxw@gmail.com",
+  "displayName": "Martin Wink",
+  "self": true
+ },
+ "start": {
+  "dateTime": "2015-06-03T10:00:00+01:00",
+  "timeZone": "Europe/London"
+ },
+ "end": {
+  "dateTime": "2015-06-03T10:25:00+01:00",
+  "timeZone": "Europe/London"
+ },
+ "recurrence": [
+  "RRULE:FREQ=YEARLY;INTERVAL=1"
+ ],
+ "iCalUID": "onn6d9kbhps6fc47m96auhtkdo@google.com",
+ "sequence": 0,
+ "reminders": {
+  "useDefault": true
+ }
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_get_calendar_primary.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_get_calendar_primary.json
@@ -1,0 +1,48 @@
+{
+
+   "kind": "calendar#calendarListEntry",
+   "etag": "\"0000000000000000\"",
+   "id": "martxw@gmail.com",
+   "summary": "martxw@gmail.com",
+   "timeZone": "Europe/London",
+   "colorId": "15",
+   "backgroundColor": "#9fc6e7",
+   "foregroundColor": "#000000",
+   "selected": true,
+   "accessRole": "owner",
+   "defaultReminders": [
+	{
+	  "method": "email",
+	  "minutes": 20
+	},
+	{
+	  "method": "sms",
+	  "minutes": 15
+	},
+	{
+	  "method": "popup",
+	  "minutes": 10
+	}
+   ],
+   "notificationSettings": {
+    "notifications": [
+     {
+      "type": "eventCreation",
+      "method": "email"
+     },
+     {
+      "type": "eventChange",
+      "method": "sms"
+     },
+     {
+      "type": "eventCancellation",
+      "method": "email"
+     },
+     {
+      "type": "eventResponse",
+      "method": "email"
+     }
+    ]
+   },
+   "primary": true
+} 

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_get_event.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_get_event.json
@@ -1,0 +1,35 @@
+{
+
+ "kind": "calendar#event",
+ "etag": "\"2790377457886000\"",
+ "id": "_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g6oo4agph751kah9o84r46ghg64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g891jeh9o88qk6cpk612k6c1k6ss3idi488o36h1i8p1k6hhp6oog",
+ "status": "confirmed",
+ "htmlLink": "https://www.google.com/calendar/event?eid=YXNzcWs3YzhuM2o3MWppb2ZjN2Z1OGFtaXMgbWFydHh3aW5rQG0",
+ "created": "2014-01-15T13:28:42.000Z",
+ "updated": "2014-03-19T13:47:24.437Z",
+ "summary": "Wearable Tech Show",
+ "description": "http://www.wearabletechnologyshow.net/#loginbox",
+ "location": "Olympia",
+ "creator": {
+  "email": "martxw@gmail.com",
+  "displayName": "Martin Wink",
+  "self": true
+ },
+ "organizer": {
+  "email": "martxw@gmail.com",
+  "displayName": "Martin Wink",
+  "self": true
+ },
+ "start": {
+  "date": "2014-03-19"
+ },
+ "end": {
+  "date": "2014-03-20"
+ },
+ "transparency": "transparent",
+ "iCalUID": "assqk7c8n3j71jiofc7fu8amis@google.com",
+ "sequence": 0,
+ "reminders": {
+  "useDefault": false
+ }
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_calendars.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_calendars.json
@@ -1,0 +1,135 @@
+{
+ "kind": "calendar#calendarList",
+ "etag": "\"0000000000000000\"",
+ "nextSyncToken": "000000000000000a",
+ "items": [
+  {
+
+   "kind": "calendar#calendarListEntry",
+   "etag": "\"0000000000000000\"",
+   "id": "martxw@gmail.com",
+   "summary": "martxw@gmail.com",
+   "timeZone": "Europe/London",
+   "colorId": "15",
+   "backgroundColor": "#9fc6e7",
+   "foregroundColor": "#000000",
+   "selected": true,
+   "accessRole": "owner",
+   "defaultReminders": [
+	{
+	  "method": "email",
+	  "minutes": 20
+	},
+	{
+	  "method": "sms",
+	  "minutes": 15
+	},
+	{
+	  "method": "popup",
+	  "minutes": 10
+	}
+   ],
+   "notificationSettings": {
+    "notifications": [
+     {
+      "type": "eventCreation",
+      "method": "email"
+     },
+     {
+      "type": "eventChange",
+      "method": "sms"
+     },
+     {
+      "type": "eventCancellation",
+      "method": "email"
+     },
+     {
+      "type": "eventResponse",
+      "method": "email"
+     }
+    ]
+   },
+   "primary": true
+  },
+  {
+
+   "kind": "calendar#calendarListEntry",
+   "etag": "\"0000000000000001\"",
+   "id": "en.uk#holiday@group.v.calendar.google.com",
+   "summary": "Holidays in United Kingdom",
+   "description": "Holidays and Observances in United Kingdom",
+   "timeZone": "Europe/London",
+   "colorId": "2",
+   "backgroundColor": "#d06b64",
+   "foregroundColor": "#000000",
+   "selected": true,
+   "accessRole": "reader",
+   "defaultReminders": [
+   ],
+   "notificationSettings": {
+   }
+  },
+  {
+
+   "kind": "calendar#calendarListEntry",
+   "etag": "\"0000000000000002\"",
+   "id": "missing_values#martxw@gmail.com"
+  },
+  {
+
+   "kind": "calendar#calendarListEntry",
+   "etag": "\"0000000000000003\"",
+   "id": "alternate_values_1#martxw@gmail.com",
+   "summary": "",
+   "description": "",
+   "location": "Somewhere",
+   "timeZone": "Europe/Paris",
+   "summaryOverride": "My title",
+   "colorId": "",
+   "backgroundColor": "",
+   "foregroundColor": "",
+   "hidden": true,
+   "selected": false,
+   "accessRole": "writer",
+   "defaultReminders": [
+	{
+	}
+   ],
+   "notificationSettings": {
+    "notifications": [
+    ]
+   },
+   "primary": false,
+   "deleted": true,
+   "defaultReminders": [
+   ]
+  },
+  {
+
+   "kind": "calendar#calendarListEntry",
+   "etag": "\"0000000000000004\"",
+   "id": "alternate_values_2#martxw@gmail.com",
+   "summary": "",
+   "description": "",
+   "location": "Somewhere",
+   "timeZone": "",
+   "summaryOverride": "",
+   "colorId": "",
+   "backgroundColor": "",
+   "foregroundColor": "",
+   "hidden": true,
+   "selected": false,
+   "accessRole": "freeBusyReader",
+   "primary": false,
+   "deleted": true,
+   "defaultReminders": [
+   ],
+   "notificationSettings": {
+    "notifications": [
+     {
+     }
+    ]
+   }
+  }
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events.json
@@ -1,0 +1,5046 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"1415499182398000\"",
+ "summary": "Phases of the Moon",
+ "description": "Shows the primary phases of the Moon",
+ "updated": "2014-11-09T02:13:02.398Z",
+ "timeZone": "Europe/London",
+ "accessRole": "reader",
+ "defaultReminders": [
+ ],
+ "nextSyncToken": "CIDl2YTr7cECEIDl2YTr7cECGAE=",
+ "items": [
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1357358280000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNTczNTgyODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 03:58",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-01-05"
+   },
+   "end": {
+    "date": "2013-01-06"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1357358280000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 03:58",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1357933440000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNTc5MzM0NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 19:44",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-01-11"
+   },
+   "end": {
+    "date": "2013-01-12"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1357933440000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 19:44",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1358552700000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNTg1NTI3MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 23:45",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-01-18"
+   },
+   "end": {
+    "date": "2013-01-19"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1358552700000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 23:45",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1359261480000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNTkyNjE0ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 04:38",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-01-27"
+   },
+   "end": {
+    "date": "2013-01-28"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1359261480000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 04:38",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1359899760000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNTk4OTk3NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 13:56",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-02-03"
+   },
+   "end": {
+    "date": "2013-02-04"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1359899760000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 13:56",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1360480800000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjA0ODA4MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 07:20",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-02-10"
+   },
+   "end": {
+    "date": "2013-02-11"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1360480800000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 07:20",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1361133060000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjExMzMwNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 20:31",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-02-17"
+   },
+   "end": {
+    "date": "2013-02-18"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1361133060000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 20:31",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1361823960000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjE4MjM5NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 20:26",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-02-25"
+   },
+   "end": {
+    "date": "2013-02-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1361823960000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 20:26",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1362433980000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjI0MzM5ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 21:53",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-03-04"
+   },
+   "end": {
+    "date": "2013-03-05"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1362433980000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 21:53",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1363031460000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjMwMzE0NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 19:51",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-03-11"
+   },
+   "end": {
+    "date": "2013-03-12"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1363031460000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 19:51",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1363714020000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjM3MTQwMjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 17:27",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-03-19"
+   },
+   "end": {
+    "date": "2013-03-20"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1363714020000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 17:27",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1364376420000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjQzNzY0MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 09:27",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-03-27"
+   },
+   "end": {
+    "date": "2013-03-28"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1364376420000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 09:27",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1364963820000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjQ5NjM4MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 05:37",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-04-03"
+   },
+   "end": {
+    "date": "2013-04-04"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1364963820000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 05:37",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1365586500000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjU1ODY1MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 10:35",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-04-10"
+   },
+   "end": {
+    "date": "2013-04-11"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1365586500000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 10:35",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1366288260000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjYyODgyNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 13:31",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-04-18"
+   },
+   "end": {
+    "date": "2013-04-19"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1366288260000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 13:31",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1366919820000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjY5MTk4MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 20:57",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-04-25"
+   },
+   "end": {
+    "date": "2013-04-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1366919820000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 20:57",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1367493240000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjc0OTMyNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 12:14",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-05-02"
+   },
+   "end": {
+    "date": "2013-05-03"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1367493240000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 12:14",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1368145740000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjgxNDU3NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 01:29",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-05-10"
+   },
+   "end": {
+    "date": "2013-05-11"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1368145740000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 01:29",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1368851700000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjg4NTE3MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 05:35",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-05-18"
+   },
+   "end": {
+    "date": "2013-05-19"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1368851700000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 05:35",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1369455900000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNjk0NTU5MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 05:25",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-05-25"
+   },
+   "end": {
+    "date": "2013-05-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1369455900000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 05:25",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1370026680000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzAwMjY2ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 19:58",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-05-31"
+   },
+   "end": {
+    "date": "2013-06-01"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1370026680000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 19:58",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1370706960000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzA3MDY5NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 16:56",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-06-08"
+   },
+   "end": {
+    "date": "2013-06-09"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1370706960000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 16:56",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1371403440000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzE0MDM0NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 18:24",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-06-16"
+   },
+   "end": {
+    "date": "2013-06-17"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1371403440000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 18:24",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1371987120000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzE5ODcxMjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 12:32",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-06-23"
+   },
+   "end": {
+    "date": "2013-06-24"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1371987120000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 12:32",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1372568040000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzI1NjgwNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 05:54",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-06-30"
+   },
+   "end": {
+    "date": "2013-07-01"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1372568040000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 05:54",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1373267640000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzMyNjc2NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 08:14",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-07-08"
+   },
+   "end": {
+    "date": "2013-07-09"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1373267640000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 08:14",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1373944680000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzM5NDQ2ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 04:18",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-07-16"
+   },
+   "end": {
+    "date": "2013-07-17"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1373944680000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 04:18",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1374516900000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzQ1MTY5MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 19:15",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-07-22"
+   },
+   "end": {
+    "date": "2013-07-23"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1374516900000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 19:15",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1375119780000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzUxMTk3ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 18:43",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-07-29"
+   },
+   "end": {
+    "date": "2013-07-30"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1375119780000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 18:43",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1375825860000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzU4MjU4NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 22:51",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-08-06"
+   },
+   "end": {
+    "date": "2013-08-07"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1375825860000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 22:51",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1376477760000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzY0Nzc3NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 11:56",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-08-14"
+   },
+   "end": {
+    "date": "2013-08-15"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1376477760000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 11:56",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1377049500000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzcwNDk1MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 02:45",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-08-21"
+   },
+   "end": {
+    "date": "2013-08-22"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1377049500000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 02:45",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1377682500000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzc2ODI1MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 10:35",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-08-28"
+   },
+   "end": {
+    "date": "2013-08-29"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1377682500000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 10:35",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1378380960000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzgzODA5NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 12:36",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-09-05"
+   },
+   "end": {
+    "date": "2013-09-06"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1378380960000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 12:36",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1379005680000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzkwMDU2ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 18:08",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-09-12"
+   },
+   "end": {
+    "date": "2013-09-13"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1379005680000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 18:08",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1379589180000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzNzk1ODkxODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 12:13",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-09-19"
+   },
+   "end": {
+    "date": "2013-09-20"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1379589180000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 12:13",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1380254160000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODAyNTQxNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 04:56",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-09-27"
+   },
+   "end": {
+    "date": "2013-09-28"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1380254160000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 04:56",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1380933300000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODA5MzMzMDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 01:35",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-10-05"
+   },
+   "end": {
+    "date": "2013-10-06"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1380933300000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 01:35",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1381532520000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODE1MzI1MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 00:02",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-10-12"
+   },
+   "end": {
+    "date": "2013-10-13"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1381532520000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 00:02",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1382139480000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODIxMzk0ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 00:38",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-10-19"
+   },
+   "end": {
+    "date": "2013-10-20"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1382139480000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 00:38",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1382830860000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODI4MzA4NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 00:41",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-10-27"
+   },
+   "end": {
+    "date": "2013-10-28"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1382830860000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 00:41",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1383483000000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODM0ODMwMDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 12:50",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-11-03"
+   },
+   "end": {
+    "date": "2013-11-04"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1383483000000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 12:50",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1384063020000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODQwNjMwMjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 05:57",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-11-10"
+   },
+   "end": {
+    "date": "2013-11-11"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1384063020000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 05:57",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1384701360000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODQ3MDEzNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 15:16",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-11-17"
+   },
+   "end": {
+    "date": "2013-11-18"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1384701360000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 15:16",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1385407680000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODU0MDc2ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 19:28",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-11-25"
+   },
+   "end": {
+    "date": "2013-11-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1385407680000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 19:28",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1386030120000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODYwMzAxMjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 00:22",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-12-03"
+   },
+   "end": {
+    "date": "2013-12-04"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1386030120000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 00:22",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1386601920000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODY2MDE5MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 15:12",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-12-09"
+   },
+   "end": {
+    "date": "2013-12-10"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1386601920000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 15:12",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1387272480000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODcyNzI0ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 09:28",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-12-17"
+   },
+   "end": {
+    "date": "2013-12-18"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1387272480000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 09:28",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1387979280000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODc5NzkyODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 13:48",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2013-12-25"
+   },
+   "end": {
+    "date": "2013-12-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1387979280000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 13:48",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1388574840000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODg1NzQ4NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 11:14",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-01-01"
+   },
+   "end": {
+    "date": "2014-01-02"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1388574840000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 11:14",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1389152340000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODkxNTIzNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 03:39",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-01-08"
+   },
+   "end": {
+    "date": "2014-01-09"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1389152340000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 03:39",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1389847920000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzODk4NDc5MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 04:52",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-01-16"
+   },
+   "end": {
+    "date": "2014-01-17"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1389847920000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 04:52",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1390540740000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTA1NDA3NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 05:19",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-01-24"
+   },
+   "end": {
+    "date": "2014-01-25"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1390540740000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 05:19",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1391117940000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTExMTc5NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 21:39",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-01-30"
+   },
+   "end": {
+    "date": "2014-01-31"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1391117940000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 21:39",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1391714520000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTE3MTQ1MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 19:22",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-02-06"
+   },
+   "end": {
+    "date": "2014-02-07"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1391714520000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 19:22",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1392421980000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTI0MjE5ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 23:53",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-02-14"
+   },
+   "end": {
+    "date": "2014-02-15"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1392421980000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 23:53",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1393089300000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTMwODkzMDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 17:15",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-02-22"
+   },
+   "end": {
+    "date": "2014-02-23"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1393089300000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 17:15",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1393660800000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTM2NjA4MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 08:00",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-03-01"
+   },
+   "end": {
+    "date": "2014-03-02"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1393660800000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 08:00",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1394285220000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTQyODUyMjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 13:27",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-03-08"
+   },
+   "end": {
+    "date": "2014-03-09"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1394285220000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 13:27",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1394989740000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTQ5ODk3NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 17:09",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-03-16"
+   },
+   "end": {
+    "date": "2014-03-17"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1394989740000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 17:09",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1395625560000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTU2MjU1NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 01:46",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-03-24"
+   },
+   "end": {
+    "date": "2014-03-25"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1395625560000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 01:46",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1396205100000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTYyMDUxMDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 19:45",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-03-30"
+   },
+   "end": {
+    "date": "2014-03-31"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1396205100000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 19:45",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1396859460000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTY4NTk0NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 09:31",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-04-07"
+   },
+   "end": {
+    "date": "2014-04-08"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1396859460000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 09:31",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1397547720000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTc1NDc3MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 08:42",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-04-15"
+   },
+   "end": {
+    "date": "2014-04-16"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1397547720000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 08:42",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1398153120000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTgxNTMxMjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 08:52",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-04-22"
+   },
+   "end": {
+    "date": "2014-04-23"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1398153120000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 08:52",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1398752040000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTg3NTIwNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 07:14",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-04-29"
+   },
+   "end": {
+    "date": "2014-04-30"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1398752040000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 07:14",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1399432500000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzEzOTk0MzI1MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 04:15",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-05-07"
+   },
+   "end": {
+    "date": "2014-05-08"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1399432500000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 04:15",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1400094960000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDAwOTQ5NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 20:16",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-05-14"
+   },
+   "end": {
+    "date": "2014-05-15"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1400094960000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 20:16",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1400677140000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDA2NzcxNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 13:59",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-05-21"
+   },
+   "end": {
+    "date": "2014-05-22"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1400677140000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 13:59",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1401302400000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDEzMDI0MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 19:40",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-05-28"
+   },
+   "end": {
+    "date": "2014-05-29"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1401302400000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 19:40",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1402000740000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDIwMDA3NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 21:39",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-06-05"
+   },
+   "end": {
+    "date": "2014-06-06"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1402000740000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 21:39",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1402632660000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDI2MzI2NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 05:11",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-06-13"
+   },
+   "end": {
+    "date": "2014-06-14"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1402632660000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 05:11",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1403203140000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDMyMDMxNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 19:39",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-06-19"
+   },
+   "end": {
+    "date": "2014-06-20"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1403203140000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 19:39",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1403856540000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDM4NTY1NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 09:09",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-06-27"
+   },
+   "end": {
+    "date": "2014-06-28"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1403856540000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 09:09",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1404561540000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDQ1NjE1NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 12:59",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-07-05"
+   },
+   "end": {
+    "date": "2014-07-06"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1404561540000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 12:59",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1405164300000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDUxNjQzMDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 12:25",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-07-12"
+   },
+   "end": {
+    "date": "2014-07-13"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1405164300000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 12:25",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1405735680000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDU3MzU2ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 03:08",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-07-19"
+   },
+   "end": {
+    "date": "2014-07-20"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1405735680000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 03:08",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1406414520000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDY0MTQ1MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 23:42",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-07-26"
+   },
+   "end": {
+    "date": "2014-07-27"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1406414520000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 23:42",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1407113400000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDcxMTM0MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 01:50",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-08-04"
+   },
+   "end": {
+    "date": "2014-08-05"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1407113400000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 01:50",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1407694140000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDc2OTQxNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 19:09",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-08-10"
+   },
+   "end": {
+    "date": "2014-08-11"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1407694140000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 19:09",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1408278360000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDgyNzgzNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 13:26",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-08-17"
+   },
+   "end": {
+    "date": "2014-08-18"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1408278360000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 13:26",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1408975980000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDg5NzU5ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 15:13",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-08-25"
+   },
+   "end": {
+    "date": "2014-08-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1408975980000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 15:13",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1409656260000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MDk2NTYyNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 12:11",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-09-02"
+   },
+   "end": {
+    "date": "2014-09-03"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1409656260000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 12:11",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1410226680000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTAyMjY2ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 02:38",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-09-09"
+   },
+   "end": {
+    "date": "2014-09-10"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1410226680000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 02:38",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1410833100000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTA4MzMxMDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 03:05",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-09-16"
+   },
+   "end": {
+    "date": "2014-09-17"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1410833100000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 03:05",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1411539240000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTE1MzkyNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 07:14",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-09-24"
+   },
+   "end": {
+    "date": "2014-09-25"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1411539240000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 07:14",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1412191980000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTIxOTE5ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 20:33",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-10-01"
+   },
+   "end": {
+    "date": "2014-10-02"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1412191980000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 20:33",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1412765460000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTI3NjU0NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 11:51",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-10-08"
+   },
+   "end": {
+    "date": "2014-10-09"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1412765460000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 11:51",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1413400320000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTM0MDAzMjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 20:12",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-10-15"
+   },
+   "end": {
+    "date": "2014-10-16"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1413400320000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 20:12",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1414101420000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTQxMDE0MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 22:57",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-10-23"
+   },
+   "end": {
+    "date": "2014-10-24"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1414101420000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 22:57",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1414723680000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTQ3MjM2ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 02:48",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-10-31"
+   },
+   "end": {
+    "date": "2014-11-01"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1414723680000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 02:48",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1415312580000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTUzMTI1ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 22:23",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-11-06"
+   },
+   "end": {
+    "date": "2014-11-07"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1415312580000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 22:23",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1415978160000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTU5NzgxNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 15:16",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-11-14"
+   },
+   "end": {
+    "date": "2014-11-15"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1415978160000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 15:16",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1416659520000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTY2NTk1MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 12:32",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-11-22"
+   },
+   "end": {
+    "date": "2014-11-23"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1416659520000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 12:32",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1417255560000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTcyNTU1NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 10:06",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-11-29"
+   },
+   "end": {
+    "date": "2014-11-30"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1417255560000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 10:06",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1417868820000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTc4Njg4MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 12:27",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-12-06"
+   },
+   "end": {
+    "date": "2014-12-07"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1417868820000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 12:27",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1418561460000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTg1NjE0NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 12:51",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-12-14"
+   },
+   "end": {
+    "date": "2014-12-15"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1418561460000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 12:51",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1419212160000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTkyMTIxNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 01:36",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-12-22"
+   },
+   "end": {
+    "date": "2014-12-23"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1419212160000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 01:36",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1419791460000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MTk3OTE0NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 18:31",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2014-12-28"
+   },
+   "end": {
+    "date": "2014-12-29"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1419791460000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 18:31",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1420433580000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjA0MzM1ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 04:53",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-01-05"
+   },
+   "end": {
+    "date": "2015-01-06"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1420433580000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 04:53",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1421142420000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjExNDI0MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 09:47",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-01-13"
+   },
+   "end": {
+    "date": "2015-01-14"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1421142420000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 09:47",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1421759640000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjE3NTk2NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 13:14",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-01-20"
+   },
+   "end": {
+    "date": "2015-01-21"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1421759640000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 13:14",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1422334080000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjIzMzQwODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 04:48",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-01-27"
+   },
+   "end": {
+    "date": "2015-01-28"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1422334080000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 04:48",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1423004940000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjMwMDQ5NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 23:09",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-02-03"
+   },
+   "end": {
+    "date": "2015-02-04"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1423004940000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 23:09",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1423713000000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjM3MTMwMDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 03:50",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-02-12"
+   },
+   "end": {
+    "date": "2015-02-13"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1423713000000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 03:50",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1424303220000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjQzMDMyMjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 23:47",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-02-18"
+   },
+   "end": {
+    "date": "2015-02-19"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1424303220000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 23:47",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1424884440000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjQ4ODQ0NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 17:14",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-02-25"
+   },
+   "end": {
+    "date": "2015-02-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1424884440000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 17:14",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1425578760000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjU1Nzg3NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 18:06",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-03-05"
+   },
+   "end": {
+    "date": "2015-03-06"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1425578760000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 18:06",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1426268880000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjYyNjg4ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 17:48",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-03-13"
+   },
+   "end": {
+    "date": "2015-03-14"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1426268880000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 17:48",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1426844160000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjY4NDQxNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 09:36",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-03-20"
+   },
+   "end": {
+    "date": "2015-03-21"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1426844160000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 09:36",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1427442180000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0Mjc0NDIxODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 07:43",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-03-27"
+   },
+   "end": {
+    "date": "2015-03-28"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1427442180000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 07:43",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1428149160000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjgxNDkxNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 13:06",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-04-04"
+   },
+   "end": {
+    "date": "2015-04-05"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1428149160000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 13:06",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1428810240000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0Mjg4MTAyNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 04:44",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-04-12"
+   },
+   "end": {
+    "date": "2015-04-13"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1428810240000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 04:44",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1429383420000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MjkzODM0MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 19:57",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-04-18"
+   },
+   "end": {
+    "date": "2015-04-19"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1429383420000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 19:57",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1430006100000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzAwMDYxMDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 00:55",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-04-26"
+   },
+   "end": {
+    "date": "2015-04-27"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1430006100000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 00:55",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1430710920000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzA3MTA5MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 04:42",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-05-04"
+   },
+   "end": {
+    "date": "2015-05-05"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1430710920000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 04:42",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1431340560000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzEzNDA1NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 11:36",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-05-11"
+   },
+   "end": {
+    "date": "2015-05-12"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1431340560000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 11:36",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1431922380000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzE5MjIzODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 05:13",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-05-18"
+   },
+   "end": {
+    "date": "2015-05-19"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1431922380000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 05:13",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1432574340000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzI1NzQzNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 18:19",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-05-25"
+   },
+   "end": {
+    "date": "2015-05-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1432574340000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 18:19",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1433261940000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzMyNjE5NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 17:19",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-06-02"
+   },
+   "end": {
+    "date": "2015-06-03"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1433261940000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 17:19",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1433864520000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzM4NjQ1MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 16:42",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-06-09"
+   },
+   "end": {
+    "date": "2015-06-10"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1433864520000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 16:42",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1434463500000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzQ0NjM1MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 15:05",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-06-16"
+   },
+   "end": {
+    "date": "2015-06-17"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1434463500000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 15:05",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1435143780000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzUxNDM3ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 12:03",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-06-24"
+   },
+   "end": {
+    "date": "2015-06-25"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1435143780000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 12:03",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1435803600000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzU4MDM2MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 03:20",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-07-02"
+   },
+   "end": {
+    "date": "2015-07-03"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1435803600000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 03:20",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1436387040000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzYzODcwNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 21:24",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-07-08"
+   },
+   "end": {
+    "date": "2015-07-09"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1436387040000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 21:24",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1437009840000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzcwMDk4NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 02:24",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-07-16"
+   },
+   "end": {
+    "date": "2015-07-17"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1437009840000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 02:24",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1437710640000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0Mzc3MTA2NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 05:04",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-07-24"
+   },
+   "end": {
+    "date": "2015-07-25"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1437710640000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 05:04",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1438339380000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0MzgzMzkzODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 11:43",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-07-31"
+   },
+   "end": {
+    "date": "2015-08-01"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1438339380000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 11:43",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1438912980000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0Mzg5MTI5ODAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 03:03",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-08-07"
+   },
+   "end": {
+    "date": "2015-08-08"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1438912980000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 03:03",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1439564040000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0Mzk1NjQwNDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 15:54",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-08-14"
+   },
+   "end": {
+    "date": "2015-08-15"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1439564040000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 15:54",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1440271860000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDAyNzE4NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 20:31",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-08-22"
+   },
+   "end": {
+    "date": "2015-08-23"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1440271860000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 20:31",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1440873300000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDA4NzMzMDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 19:35",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-08-29"
+   },
+   "end": {
+    "date": "2015-08-30"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1440873300000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 19:35",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1441446840000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDE0NDY4NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 10:54",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-09-05"
+   },
+   "end": {
+    "date": "2015-09-06"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1441446840000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 10:54",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1442126460000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDIxMjY0NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 07:41",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-09-13"
+   },
+   "end": {
+    "date": "2015-09-14"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1442126460000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 07:41",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1442825940000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDI4MjU5NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 09:59",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-09-21"
+   },
+   "end": {
+    "date": "2015-09-22"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1442825940000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 09:59",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1443408600000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDM0MDg2MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 03:50",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-09-28"
+   },
+   "end": {
+    "date": "2015-09-29"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1443408600000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 03:50",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1443992760000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDM5OTI3NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 22:06",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-10-04"
+   },
+   "end": {
+    "date": "2015-10-05"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1443992760000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 22:06",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1444694760000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDQ2OTQ3NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 01:06",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-10-13"
+   },
+   "end": {
+    "date": "2015-10-14"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1444694760000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 01:06",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1445373060000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDUzNzMwNjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 21:31",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-10-20"
+   },
+   "end": {
+    "date": "2015-10-21"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1445373060000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 21:31",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1445947500000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDU5NDc1MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 12:05",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-10-27"
+   },
+   "end": {
+    "date": "2015-10-28"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1445947500000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 12:05",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1446553440000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDY1NTM0NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 12:24",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-11-03"
+   },
+   "end": {
+    "date": "2015-11-04"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1446553440000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 12:24",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1447264020000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDcyNjQwMjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 17:47",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-11-11"
+   },
+   "end": {
+    "date": "2015-11-12"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1447264020000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 17:47",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1447914420000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDc5MTQ0MjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 06:27",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-11-19"
+   },
+   "end": {
+    "date": "2015-11-20"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1447914420000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 06:27",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1448491440000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDg0OTE0NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 22:44",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-11-25"
+   },
+   "end": {
+    "date": "2015-11-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1448491440000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 22:44",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1449128400000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDkxMjg0MDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Last quarter 07:40",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-12-03"
+   },
+   "end": {
+    "date": "2015-12-04"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1449128400000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Last quarter 07:40",
+    "iconLink": "https://www.google.com/calendar/images/last-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1449829740000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NDk4Mjk3NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "New moon 10:29",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-12-11"
+   },
+   "end": {
+    "date": "2015-12-12"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1449829740000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "New moon 10:29",
+    "iconLink": "https://www.google.com/calendar/images/new-moon.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1450451640000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NTA0NTE2NDAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "First quarter 15:14",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-12-18"
+   },
+   "end": {
+    "date": "2015-12-19"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1450451640000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "First quarter 15:14",
+    "iconLink": "https://www.google.com/calendar/images/first-quarter.gif"
+   }
+  },
+  {
+
+   "kind": "calendar#event",
+   "etag": "\"2453932800000000\"",
+   "id": "moonphase+1451041860000",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=bW9vbnBoYXNlKzE0NTEwNDE4NjAwMDAgaHQzamxmYWFjNWxmZDYyNjN1bGZoNHRxbDhAZw",
+   "created": "2008-11-18T00:00:00.000Z",
+   "updated": "2008-11-18T00:00:00.000Z",
+   "summary": "Full moon 11:11",
+   "creator": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "organizer": {
+    "email": "ht3jlfaac5lfd6263ulfh4tql8@group.calendar.google.com",
+    "displayName": "Phases of the Moon",
+    "self": true
+   },
+   "start": {
+    "date": "2015-12-25"
+   },
+   "end": {
+    "date": "2015-12-26"
+   },
+   "visibility": "public",
+   "iCalUID": "moonphase+1451041860000@google.com",
+   "sequence": 0,
+   "gadget": {
+    "title": "Full moon 11:11",
+    "iconLink": "https://www.google.com/calendar/images/full-moon.gif"
+   }
+  }
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_empty.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_empty.json
@@ -1,0 +1,7 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"0001\"",
+ "nextSyncToken": "0002",
+ "items": [
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_missing.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_missing.json
@@ -1,0 +1,5 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"0001\"",
+ "nextSyncToken": "0002"
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_1.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_1.json
@@ -1,0 +1,113 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"0001\"",
+ "nextSyncToken": "0002",
+ "items": [
+
+{
+  "kind": "calendar#event",
+  "etag": "\"etag1\"",
+  "id": "string1",
+  "status": "confirmed",
+  "htmlLink": "string3",
+  "created": "2000-01-01T00:00:00.000Z",
+  "updated": "2000-01-01T00:00:00.000Z",
+  "summary": "string4",
+  "description": "string5",
+  "location": "string6",
+  "colorId": "string7",
+  "creator": {
+    "id": "string8",
+    "email": "string9",
+    "displayName": "string10",
+    "self": true
+  },
+  "organizer": {
+    "id": "string11",
+    "email": "string12",
+    "displayName": "string13",
+    "self": true
+  },
+  "start": {
+    "date": "2000-01-01",
+    "dateTime": "2000-01-01T00:00:00.000Z",
+    "timeZone": "string14"
+  },
+  "end": {
+    "date": "2000-01-01",
+    "dateTime": "2000-01-01T00:00:00.000Z",
+    "timeZone": "string15"
+  },
+  "endTimeUnspecified": true,
+  "recurrence": [
+    "string16"
+  ],
+  "recurringEventId": "string17",
+  "originalStartTime": {
+    "date": "2000-01-01",
+    "dateTime": "2000-01-01T00:00:00.000Z",
+    "timeZone": "string18"
+  },
+  "transparency": "opaque",
+  "visibility": "default",
+  "iCalUID": "string21",
+  "sequence": 1,
+  "attendees": [
+    {
+      "id": "string22",
+      "email": "string23",
+      "displayName": "string24",
+      "organizer": true,
+      "self": true,
+      "resource": true,
+      "optional": true,
+      "responseStatus": "needsAction",
+      "comment": "string26",
+      "additionalGuests": 1
+    }
+  ],
+  "attendeesOmitted": true,
+  "extendedProperties": {
+    "private": {
+      "(key1)": "string27"
+    },
+    "shared": {
+      "(key2)": "string28"
+    }
+  },
+  "hangoutLink": "string29",
+  "gadget": {
+    "type": "string30",
+    "title": "string31",
+    "link": "string32",
+    "iconLink": "string33",
+    "width": 11,
+    "height": 11,
+    "display": "icon",
+    "preferences": {
+      "(key3)": "string35"
+    }
+  },
+  "anyoneCanAddSelf": true,
+  "guestsCanInviteOthers": true,
+  "guestsCanModify": true,
+  "guestsCanSeeOtherGuests": true,
+  "privateCopy": true,
+  "locked": true,
+  "reminders": {
+    "useDefault": true,
+    "overrides": [
+      {
+        "method": "email",
+        "minutes": 12
+      }
+    ]
+  },
+  "source": {
+    "url": "string37",
+    "title": "string38"
+  }
+}
+ 
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_2.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_2.json
@@ -1,0 +1,113 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"0001\"",
+ "nextSyncToken": "0002",
+ "items": [
+
+{
+  "kind": "calendar#event",
+  "etag": "\"etag1\"",
+  "id": "",
+  "status": "tentative",
+  "htmlLink": "",
+  "created": "1970-01-01T00:00:00.000Z",
+  "updated": "1970-01-01T00:00:00.000Z",
+  "summary": "",
+  "description": "",
+  "location": "",
+  "colorId": "",
+  "creator": {
+    "id": "",
+    "email": "",
+    "displayName": "",
+    "self": false
+  },
+  "organizer": {
+    "id": "",
+    "email": "",
+    "displayName": "",
+    "self": false
+  },
+  "start": {
+    "date": "1970-01-01",
+    "dateTime": "1970-01-01T00:00:00.000Z",
+    "timeZone": ""
+  },
+  "end": {
+    "date": "1970-01-01",
+    "dateTime": "1970-01-01T00:00:00.000Z",
+    "timeZone": ""
+  },
+  "endTimeUnspecified": false,
+  "recurrence": [
+    ""
+  ],
+  "recurringEventId": "",
+  "originalStartTime": {
+    "date": "1970-01-01",
+    "dateTime": "1970-01-01T00:00:00.000Z",
+    "timeZone": ""
+  },
+  "transparency": "transparent",
+  "visibility": "public",
+  "iCalUID": "",
+  "sequence": 0,
+  "attendees": [
+    {
+      "id": "",
+      "email": "",
+      "displayName": "",
+      "organizer": false,
+      "self": false,
+      "resource": false,
+      "optional": false,
+      "responseStatus": "declined",
+      "comment": "",
+      "additionalGuests": 0
+    }
+  ],
+  "attendeesOmitted": false,
+  "extendedProperties": {
+    "private": {
+      "(key1)": ""
+    },
+    "shared": {
+      "(key2)": ""
+    }
+  },
+  "hangoutLink": "",
+  "gadget": {
+    "type": "",
+    "title": "",
+    "link": "",
+    "iconLink": "",
+    "width": 0,
+    "height": 0,
+    "display": "chip",
+    "preferences": {
+      "(key3)": ""
+    }
+  },
+  "anyoneCanAddSelf": false,
+  "guestsCanInviteOthers": false,
+  "guestsCanModify": false,
+  "guestsCanSeeOtherGuests": false,
+  "privateCopy": false,
+  "locked": false,
+  "reminders": {
+    "useDefault": false,
+    "overrides": [
+      {
+        "method": "sms",
+        "minutes": 0
+      }
+    ]
+  },
+  "source": {
+    "url": "",
+    "title": ""
+  }
+}
+ 
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_3.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_3.json
@@ -1,0 +1,60 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"0001\"",
+ "nextSyncToken": "0002",
+ "items": [
+
+{
+  "kind": "calendar#event",
+  "etag": "\"etag1\"",
+  "id": "",
+  "status": "cancelled",
+  "created": "",
+  "updated": "",
+  "creator": {
+  },
+  "organizer": {
+  },
+  "start": {
+    "date": "",
+    "dateTime": ""
+  },
+  "end": {
+    "date": "",
+    "dateTime": ""
+  },
+  "recurrence": [
+  ],
+  "originalStartTime": {
+    "date": "",
+    "dateTime": ""
+  },
+  "visibility": "private",
+  "attendees": [
+    {
+      "responseStatus": "tentative"
+    }
+  ],
+  "extendedProperties": {
+    "private": {
+    },
+    "shared": {
+    }
+  },
+  "gadget": {
+    "preferences": {
+    }
+  },
+  "reminders": {
+    "overrides": [
+      {
+        "method": "popup"
+      }
+    ]
+  },
+  "source": {
+  }
+}
+ 
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_4.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_4.json
@@ -1,0 +1,36 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"0001\"",
+ "nextSyncToken": "0002",
+ "items": [
+
+{
+  "kind": "calendar#event",
+  "etag": "\"etag1\"",
+  "id": "",
+  "start": {
+  },
+  "end": {
+  },
+  "originalStartTime": {
+  },
+  "visibility": "confidential",
+  "attendees": [
+    {
+      "responseStatus": "accepted"
+    }
+  ],
+  "extendedProperties": {
+  },
+  "gadget": {
+  },
+  "reminders": {
+    "overrides": [
+      {
+      }
+    ]
+  }
+}
+ 
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_5.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_5.json
@@ -1,0 +1,22 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"0001\"",
+ "nextSyncToken": "0002",
+ "items": [
+
+{
+  "kind": "calendar#event",
+  "etag": "\"etag1\"",
+  "id": "",
+  "attendees": [
+    {
+    }
+  ],
+  "reminders": {
+    "overrides": [
+    ]
+  }
+}
+ 
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_6.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_6.json
@@ -1,0 +1,18 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"0001\"",
+ "nextSyncToken": "0002",
+ "items": [
+
+{
+  "kind": "calendar#event",
+  "etag": "\"etag1\"",
+  "id": "",
+  "attendees": [
+  ],
+  "reminders": {
+  }
+}
+ 
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_7.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/mock_list_events_values_7.json
@@ -1,0 +1,14 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"0001\"",
+ "nextSyncToken": "0002",
+ "items": [
+
+{
+  "kind": "calendar#event",
+  "etag": "\"etag1\"",
+  "id": ""
+}
+ 
+ ]
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/post_non_null_values_1_event.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/post_non_null_values_1_event.json
@@ -1,0 +1,38 @@
+{
+  "id" : "onn6d9kbhps6fc47m96auhtkdo",
+  "etag" : "\"2831656302604000\"",
+  "status" : "cancelled",
+  "htmlLink" : "https://www.google.com/calendar/event?eid=b25uNmQ5a2JocHM2ZmM0N205NmF1aHRrZG9fMjAxNTA2MDNUMDkwMDAwWiBtYXJ0eHdpbmtAbQ",
+  "created" : "2014-11-12T21:35:51.000Z",
+  "updated" : "2014-11-12T21:35:51.302Z",
+  "summary" : "New summary",
+  "location" : "Somewhere else",
+  "creator" : {
+    "email" : "martxw@gmail.com",
+    "displayName" : "Martin Wink",
+    "self" : true
+  },
+  "organizer" : {
+    "email" : "martxw@gmail.com",
+    "displayName" : "Martin Wink",
+    "self" : true
+  },
+  "start" : {
+    "date" : "2014-11-27",
+    "dateTime" : "2014-11-28T00:00:00.000Z",
+    "timeZone" : "UTC"
+  },
+  "end" : {
+    "date" : "2014-11-29",
+    "dateTime" : "2014-11-30T00:00:00.000Z",
+    "timeZone" : "PST"
+  },
+  "recurrence" : [ ],
+  "iCalUID" : "onn6d9kbhps6fc47m96auhtkdo@google.com",
+  "sequence" : 0,
+  "guestsCanInviteOthers" : true,
+  "guestsCanSeeOtherGuests" : false,
+  "reminders" : {
+    "useDefault" : true
+  }
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/post_non_null_values_2_event.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/post_non_null_values_2_event.json
@@ -1,0 +1,38 @@
+{
+  "id" : "onn6d9kbhps6fc47m96auhtkdo",
+  "etag" : "\"2831656302604000\"",
+  "status" : "tentative",
+  "htmlLink" : "https://www.google.com/calendar/event?eid=b25uNmQ5a2JocHM2ZmM0N205NmF1aHRrZG9fMjAxNTA2MDNUMDkwMDAwWiBtYXJ0eHdpbmtAbQ",
+  "created" : "2014-11-12T21:35:51.000Z",
+  "updated" : "2014-11-12T21:35:51.302Z",
+  "summary" : "Another title",
+  "location" : "Another place",
+  "creator" : {
+    "email" : "martxw@gmail.com",
+    "displayName" : "Martin Wink",
+    "self" : true
+  },
+  "organizer" : {
+    "email" : "martxw@gmail.com",
+    "displayName" : "Martin Wink",
+    "self" : true
+  },
+  "start" : {
+    "date" : "2013-11-27",
+    "dateTime" : "2013-11-28T00:00:00.000Z",
+    "timeZone" : "CET"
+  },
+  "end" : {
+    "date" : "2013-11-29",
+    "dateTime" : "2013-11-30T00:00:00.000Z",
+    "timeZone" : "MST"
+  },
+  "recurrence" : [ "RRULE:FREQ=MONTHLY;INTERVAL=1", "RRULE:FREQ=MONTHLY;INTERVAL=3" ],
+  "iCalUID" : "onn6d9kbhps6fc47m96auhtkdo@google.com",
+  "sequence" : 0,
+  "guestsCanInviteOthers" : false,
+  "guestsCanSeeOtherGuests" : true,
+  "reminders" : {
+    "useDefault" : true
+  }
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/post_null_values_event.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/post_null_values_event.json
@@ -1,0 +1,24 @@
+{
+  "id" : "onn6d9kbhps6fc47m96auhtkdo",
+  "etag" : "\"2831656302604000\"",
+  "htmlLink" : "https://www.google.com/calendar/event?eid=b25uNmQ5a2JocHM2ZmM0N205NmF1aHRrZG9fMjAxNTA2MDNUMDkwMDAwWiBtYXJ0eHdpbmtAbQ",
+  "created" : "2014-11-12T21:35:51.000Z",
+  "updated" : "2014-11-12T21:35:51.302Z",
+  "creator" : {
+    "email" : "martxw@gmail.com",
+    "displayName" : "Martin Wink",
+    "self" : true
+  },
+  "organizer" : {
+    "email" : "martxw@gmail.com",
+    "displayName" : "Martin Wink",
+    "self" : true
+  },
+  "start" : { },
+  "end" : { },
+  "iCalUID" : "onn6d9kbhps6fc47m96auhtkdo@google.com",
+  "sequence" : 0,
+  "reminders" : {
+    "useDefault" : true
+  }
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/post_unmodified_event.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/post_unmodified_event.json
@@ -1,0 +1,36 @@
+{
+  "id" : "onn6d9kbhps6fc47m96auhtkdo",
+  "etag" : "\"2831656302604000\"",
+  "status" : "confirmed",
+  "htmlLink" : "https://www.google.com/calendar/event?eid=b25uNmQ5a2JocHM2ZmM0N205NmF1aHRrZG9fMjAxNTA2MDNUMDkwMDAwWiBtYXJ0eHdpbmtAbQ",
+  "created" : "2014-11-12T21:35:51.000Z",
+  "updated" : "2014-11-12T21:35:51.302Z",
+  "summary" : "Appointment at Somewhere",
+  "location" : "Somewhere",
+  "creator" : {
+    "email" : "martxw@gmail.com",
+    "displayName" : "Martin Wink",
+    "self" : true
+  },
+  "organizer" : {
+    "email" : "martxw@gmail.com",
+    "displayName" : "Martin Wink",
+    "self" : true
+  },
+  "start" : {
+    "dateTime" : "2015-06-03T09:00:00.000Z",
+    "timeZone" : "Europe/London"
+  },
+  "end" : {
+    "dateTime" : "2015-06-03T09:25:00.000Z",
+    "timeZone" : "Europe/London"
+  },
+  "recurrence" : [ "RRULE:FREQ=YEARLY;INTERVAL=1" ],
+  "iCalUID" : "onn6d9kbhps6fc47m96auhtkdo@google.com",
+  "sequence" : 0,
+  "guestsCanInviteOthers" : true,
+  "guestsCanSeeOtherGuests" : true,
+  "reminders" : {
+    "useDefault" : true
+  }
+}

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/pre_modification_event.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/calendar/pre_modification_event.json
@@ -1,0 +1,37 @@
+{
+ "kind": "calendar#event",
+ "etag": "\"2831656302604000\"",
+ "id": "onn6d9kbhps6fc47m96auhtkdo",
+ "status": "confirmed",
+ "htmlLink": "https://www.google.com/calendar/event?eid=b25uNmQ5a2JocHM2ZmM0N205NmF1aHRrZG9fMjAxNTA2MDNUMDkwMDAwWiBtYXJ0eHdpbmtAbQ",
+ "created": "2014-11-12T21:35:51.000Z",
+ "updated": "2014-11-12T21:35:51.302Z",
+ "summary": "Appointment at Somewhere",
+ "location": "Somewhere",
+ "creator": {
+  "email": "martxw@gmail.com",
+  "displayName": "Martin Wink",
+  "self": true
+ },
+ "organizer": {
+  "email": "martxw@gmail.com",
+  "displayName": "Martin Wink",
+  "self": true
+ },
+ "start": {
+  "dateTime": "2015-06-03T10:00:00+01:00",
+  "timeZone": "Europe/London"
+ },
+ "end": {
+  "dateTime": "2015-06-03T10:25:00+01:00",
+  "timeZone": "Europe/London"
+ },
+ "recurrence": [
+  "RRULE:FREQ=YEARLY;INTERVAL=1"
+ ],
+ "iCalUID": "onn6d9kbhps6fc47m96auhtkdo@google.com",
+ "sequence": 0,
+ "reminders": {
+  "useDefault": true
+ }
+}


### PR DESCRIPTION
Implemented package org.springframework.social.google.api.calendar and org.springframework.social.google.api.calendar.impl, and offline autotests.
Also see spring-social-google-example updates for manual online testing.

Within the existing code I've moved encode() up a level to QueryBuilderImpl so it's available to all builders.
Also includes a fix for issue #62 - wrong time format in QueryBuilderImpl.
In AbstractGoogleApiOperations constructor I add an error handler to the restTemplate to log the response body, since Google sends back JSON that explains the error, for instance lack of permission. 