### PR TITLE
added support for Google Accounts Authentication and Authorization API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ spring-social-core/src/test/java/exploration
 **/.project
 **/.settings
 **/bin
+/bin/

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/Google.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/Google.java
@@ -18,6 +18,7 @@ package org.springframework.social.google.api;
 import org.springframework.social.ApiBinding;
 import org.springframework.social.google.api.drive.DriveOperations;
 import org.springframework.social.google.api.impl.GoogleTemplate;
+import org.springframework.social.google.api.oauth2.OAuth2Operations;
 import org.springframework.social.google.api.plus.PlusOperations;
 import org.springframework.social.google.api.tasks.TaskOperations;
 
@@ -29,6 +30,14 @@ import org.springframework.social.google.api.tasks.TaskOperations;
  */
 public interface Google extends ApiBinding {
 
+	/**
+	 * Retrieves {@link OAuth2Operations}, used for interacting with Google+ API.
+	 *
+	 * @return {@link PlusOperations} for the authenticated user if
+	 *         authenticated
+	 */
+	OAuth2Operations oauth2Operations();
+	
 	/**
 	 * Retrieves {@link PlusOperations}, used for interacting with Google+ API.
 	 * Some methods require OAuth2 scope https://www.googleapis.com/auth/plus.me

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/impl/GoogleTemplate.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/impl/GoogleTemplate.java
@@ -31,6 +31,8 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.social.google.api.Google;
 import org.springframework.social.google.api.drive.DriveOperations;
 import org.springframework.social.google.api.drive.impl.DriveTemplate;
+import org.springframework.social.google.api.oauth2.OAuth2Operations;
+import org.springframework.social.google.api.oauth2.impl.OAuth2Template;
 import org.springframework.social.google.api.plus.PlusOperations;
 import org.springframework.social.google.api.plus.impl.PlusTemplate;
 import org.springframework.social.google.api.tasks.TaskOperations;
@@ -55,7 +57,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
 	
 	private String accessToken;
-
+	private OAuth2Operations oauth2Operations;
 	private PlusOperations plusOperations;
 	private TaskOperations taskOperations;
 	private DriveOperations driveOperations;
@@ -80,6 +82,7 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
 	}
 
 	private void initialize() {
+		oauth2Operations = new OAuth2Template(getRestTemplate(), isAuthorized());
 		plusOperations = new PlusTemplate(getRestTemplate(), isAuthorized());
 		taskOperations = new TaskTemplate(getRestTemplate(), isAuthorized());
 		driveOperations = new DriveTemplate(getRestTemplate(), isAuthorized());
@@ -130,6 +133,11 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
 	@Override
 	public String getAccessToken() {
 		return accessToken;
+	}
+
+	@Override
+	public OAuth2Operations oauth2Operations() {
+		return oauth2Operations;
 	}
 
 }

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/oauth2/OAuth2Operations.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/oauth2/OAuth2Operations.java
@@ -1,0 +1,27 @@
+package org.springframework.social.google.api.oauth2;
+
+import org.springframework.social.google.api.plus.Person;
+
+/**
+ * Defines operations for Google Accounts Authentification and Authorization. Requires OAuth scope(s)
+ * from the following:
+ * <ul>
+ * <li>openid/li>
+ * <li>profile</li>
+ * <li>email</li>
+ * </ul>
+ * See <a
+ * href="https://developers.google.com/accounts/docs/OpenIDConnect">https://developers.google.com/accounts/docs/OpenIDConnect</a> for details about the different scopes
+ * 
+ * @author Charles Maheu
+ * 
+ */
+public interface OAuth2Operations {
+
+	/**
+	 * Retrieves the authenticated user's Google user.
+	 * 
+	 * @return the retrieved {@link Person}
+	 */
+	UserInfo getUserinfo();
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/oauth2/UserInfo.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/oauth2/UserInfo.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.oauth2;
+
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.springframework.social.google.api.ApiEntity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+/**
+ * Model class representing a Google user
+ * 
+ * @author Charles
+ */
+public class UserInfo extends ApiEntity {
+
+	@JsonProperty
+	private String name;
+	
+	@JsonProperty("given_name")
+	private String givenName;
+	
+	@JsonProperty("family_name")
+	private String familyName;
+	
+	@JsonProperty
+	private String gender;
+	
+	@JsonProperty
+	private String picture;
+	
+	@JsonProperty
+	private String link;
+	
+	@JsonProperty
+	private String email;
+	
+	@JsonProperty("verified_email")
+	private String verifiedEmail;
+	
+	@JsonProperty
+	private String hd;
+	
+	@JsonProperty
+	private String locale;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getGivenName() {
+		return givenName;
+	}
+
+	public void setGivenName(String givenName) {
+		this.givenName = givenName;
+	}
+
+	public String getFamilyName() {
+		return familyName;
+	}
+
+	public void setFamilyName(String familyName) {
+		this.familyName = familyName;
+	}
+
+	public String getGender() {
+		return gender;
+	}
+
+	public void setGender(String gender) {
+		this.gender = gender;
+	}
+
+	public String getPicture() {
+		return picture;
+	}
+
+	public void setPicture(String picture) {
+		this.picture = picture;
+	}
+
+	public String getLink() {
+		return link;
+	}
+
+	public void setLink(String link) {
+		this.link = link;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getVerifiedEmail() {
+		return verifiedEmail;
+	}
+
+	public void setVerifiedEmail(String verifiedEmail) {
+		this.verifiedEmail = verifiedEmail;
+	}
+
+	public String getHd() {
+		return hd;
+	}
+
+	public void setHd(String hd) {
+		this.hd = hd;
+	}
+
+	public String getLocale() {
+		return locale;
+	}
+
+	public void setLocale(String locale) {
+		this.locale = locale;
+	}
+
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/oauth2/impl/OAuth2Template.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/oauth2/impl/OAuth2Template.java
@@ -1,0 +1,21 @@
+package org.springframework.social.google.api.oauth2.impl;
+
+import org.springframework.social.google.api.impl.AbstractGoogleApiOperations;
+import org.springframework.social.google.api.oauth2.OAuth2Operations;
+import org.springframework.social.google.api.oauth2.UserInfo;
+import org.springframework.web.client.RestTemplate;
+
+public class OAuth2Template  extends AbstractGoogleApiOperations implements OAuth2Operations {
+
+	private static final String USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+	
+	public OAuth2Template(RestTemplate restTemplate, boolean isAuthorized) {
+		super(restTemplate, isAuthorized);
+	}
+
+	@Override
+	public UserInfo getUserinfo() {
+			return getEntity(USERINFO_URL, UserInfo.class);
+	}
+
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/connect/GoogleAdapter.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/connect/GoogleAdapter.java
@@ -21,6 +21,7 @@ import org.springframework.social.connect.ConnectionValues;
 import org.springframework.social.connect.UserProfile;
 import org.springframework.social.connect.UserProfileBuilder;
 import org.springframework.social.google.api.Google;
+import org.springframework.social.google.api.oauth2.UserInfo;
 import org.springframework.social.google.api.plus.Person;
 
 /**
@@ -32,7 +33,7 @@ public class GoogleAdapter implements ApiAdapter<Google> {
 
 	public boolean test(Google google) {
 		try {
-			google.plusOperations().getGoogleProfile();
+			google.oauth2Operations().getUserinfo();
 			return true;
 		} catch (ApiException e) {
 			return false;
@@ -40,20 +41,20 @@ public class GoogleAdapter implements ApiAdapter<Google> {
 	}
 
 	public void setConnectionValues(Google google, ConnectionValues values) {
-		Person profile = google.plusOperations().getGoogleProfile();
-		values.setProviderUserId(profile.getId());
-		values.setDisplayName(profile.getDisplayName());
-		values.setProfileUrl(profile.getUrl());
-		values.setImageUrl(profile.getImageUrl());
+		UserInfo userInfo = google.oauth2Operations().getUserinfo();
+		values.setProviderUserId(userInfo.getId());
+		values.setDisplayName(userInfo.getName());
+		values.setProfileUrl(userInfo.getLink());
+		values.setImageUrl(userInfo.getPicture());
 	}
 
 	public UserProfile fetchUserProfile(Google google) {
-		Person profile = google.plusOperations().getGoogleProfile();
-		return new UserProfileBuilder().setUsername(profile.getId())
-				.setEmail(profile.getAccountEmail())
-				.setName(profile.getDisplayName())
-				.setFirstName(profile.getGivenName())
-				.setLastName(profile.getFamilyName()).build();
+		UserInfo userInfo = google.oauth2Operations().getUserinfo();
+		return new UserProfileBuilder().setUsername(userInfo.getId())
+				.setEmail(userInfo.getEmail())
+				.setName(userInfo.getName())
+				.setFirstName(userInfo.getGivenName())
+				.setLastName(userInfo.getFamilyName()).build();
 	}
 
 	public void updateStatus(Google google, String message) {

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/oauth2/Oauth2TemplateTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/oauth2/Oauth2TemplateTests.java
@@ -1,0 +1,39 @@
+package org.springframework.social.google.api.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.junit.Test;
+import org.springframework.social.google.api.AbstractGoogleApiTest;
+import org.springframework.social.google.api.plus.Person;
+
+public class Oauth2TemplateTests extends AbstractGoogleApiTest {
+
+	
+	@Test
+	public void getUserInfo() {
+		mockServer
+				.expect(requestTo("https://www.googleapis.com/oauth2/v2/userinfo"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("userinfo"), APPLICATION_JSON));
+		UserInfo userInfo = google.oauth2Operations().getUserinfo();
+		assertUserInfo(userInfo);
+	}
+
+	private void assertUserInfo(UserInfo userInfo) {
+		assertNotNull(userInfo);
+		assertEquals("115195428470189335897",userInfo.getId());
+		assertEquals("charles maheu",userInfo.getName());
+		assertEquals("charles",userInfo.getGivenName());
+		assertEquals("maheu",userInfo.getFamilyName());
+		assertEquals("choc.mah@gmail.com",userInfo.getEmail());
+		assertEquals("https://plus.google.com/115195428470189335897",userInfo.getLink());
+		assertEquals("https://lh6.googleusercontent.com/-f5nUw3UA0Cc/AAAAAAAAAAI/AAAAAAAAABw/1r78kB5lAEg/photo.jpg",userInfo.getPicture());
+	}
+}

--- a/spring-social-google/src/test/java/org/springframework/social/google/connect/GoogleAdapterTest.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/connect/GoogleAdapterTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.social.connect.UserProfile;
 import org.springframework.social.google.api.Google;
+import org.springframework.social.google.api.oauth2.OAuth2Operations;
+import org.springframework.social.google.api.oauth2.UserInfo;
 import org.springframework.social.google.api.plus.Person;
 import org.springframework.social.google.api.plus.PlusOperations;
 
@@ -33,17 +35,17 @@ public class GoogleAdapterTest {
 	@Test
 	public void fetchProfile() {
 
-		PlusOperations plusOperations = Mockito.mock(PlusOperations.class);
-		Mockito.when(google.plusOperations()).thenReturn(plusOperations);
+		OAuth2Operations oauth2Operations = Mockito.mock(OAuth2Operations.class);
+		Mockito.when(google.oauth2Operations()).thenReturn(oauth2Operations);
 
-		Person person = Mockito.mock(Person.class);
-		Mockito.when(person.getDisplayName()).thenReturn("Gabriel Axel");
-		Mockito.when(person.getGivenName()).thenReturn("Gabriel");
-		Mockito.when(person.getFamilyName()).thenReturn("Axel");
-		Mockito.when(person.getAccountEmail()).thenReturn("guznik@gmail.com");
-		Mockito.when(person.getId()).thenReturn("114863353858610846998");
+		UserInfo userInfo = Mockito.mock(UserInfo.class);
+		Mockito.when(userInfo.getName()).thenReturn("Gabriel Axel");
+		Mockito.when(userInfo.getGivenName()).thenReturn("Gabriel");
+		Mockito.when(userInfo.getFamilyName()).thenReturn("Axel");
+		Mockito.when(userInfo.getEmail()).thenReturn("guznik@gmail.com");
+		Mockito.when(userInfo.getId()).thenReturn("114863353858610846998");
 
-		Mockito.when(plusOperations.getGoogleProfile()).thenReturn(person);
+		Mockito.when(oauth2Operations.getUserinfo()).thenReturn(userInfo);
 		UserProfile profile = apiAdapter.fetchUserProfile(google);
 		assertEquals("Gabriel Axel", profile.getName());
 		assertEquals("Gabriel", profile.getFirstName());

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/oauth2/userinfo.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/oauth2/userinfo.json
@@ -1,0 +1,12 @@
+{
+ "id": "115195428470189335897",
+ "email": "choc.mah@gmail.com",
+ "verified_email": true,
+ "name": "charles maheu",
+ "given_name": "charles",
+ "family_name": "maheu",
+ "link": "https://plus.google.com/115195428470189335897",
+ "picture": "https://lh6.googleusercontent.com/-f5nUw3UA0Cc/AAAAAAAAAAI/AAAAAAAAABw/1r78kB5lAEg/photo.jpg",
+ "gender": "male",
+ "locale": "en"
+}


### PR DESCRIPTION
Added support for Google Accounts API and changed GoogleAdapter implementation

The problem was that the Google+ API  is not activated for every Google user (..it's can be deactivated for  Google Apps Entreprise domain in example) So we are unable to  authenticate those user. On the other hand  The Google Accounts API is always activated for every google user.

Also, with this you do not need to activate the Google+ API in the developer console
see https://github.com/GabiAxel/spring-social-google/issues/22