### PR TITLE
Support listing, adding/modifying, removing and querying on Drive custom properties

### DIFF
--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveFileQueryBuilder.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveFileQueryBuilder.java
@@ -74,6 +74,8 @@ public interface DriveFileQueryBuilder extends ApiQueryBuilder<DriveFileQueryBui
 
 	DriveFileQueryBuilder sharedWithMe();
 
+	DriveFileQueryBuilder propertiesHas(String propertyKey, String propertyValue, PropertyVisibility visibility);
+
 	DriveFileQueryBuilder isFolder();
 
 	DriveFileQueryBuilder isFile();

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveOperations.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveOperations.java
@@ -393,4 +393,58 @@ public interface DriveOperations {
 	 * @return Resource abstraction for the file
 	 */
 	Resource downloadFile(DriveFile file);
+
+	/**
+	 * Get the custom properties applied to this file
+	 * 
+	 * @param fileId
+	 *            The ID of the file
+	 * @return
+	 *            The list of properties defined
+	 */
+	List<FileProperty> getProperties(String fileId);
+
+	/**
+	 * Get a specific custom property applied to this file
+	 * 
+	 * @param fileId
+	 *            The ID of the file
+	 * @param propertyKey
+	 *            The key of the property
+	 * @return
+	 *            The the property information
+	 */
+	FileProperty getProperty(String fileId, String propertyKey);
+
+	/**
+	 * Adds a new property to a file
+	 * 
+	 * @param fileId
+	 *            The ID of the file
+	 * @param property
+	 *            Property representation
+	 * @return The new {@link FileProperty}
+	 */
+	FileProperty addProperty(String fileId, FileProperty property);
+
+	/**
+	 * Updates a property
+	 * 
+	 * @param fileId
+	 *            The ID of the file
+	 * @param property
+	 *            Property representation
+	 * @return The updated {@link FileProperty}
+	 */
+	FileProperty updateProperty(String fileId, FileProperty property);
+
+	/**
+	 * Deletes a property
+	 * 
+	 * @param fileId
+	 *            The ID of the file
+	 * @param propertyKey
+	 *            The key of the property
+	 */
+	void removeProperty(String fileId, String propertyKey);
 }

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/FileProperty.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/FileProperty.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.drive;
+
+import org.springframework.social.google.api.ApiEntity;
+
+/**
+ * Model class representing a custom property set on a file in Google Drive
+ * 
+ * @author Will Abson
+ */
+public class FileProperty extends ApiEntity {
+
+	private String key;
+
+	private String value;
+
+	private PropertyVisibility visibility;
+
+	public FileProperty() {
+	}
+
+	public FileProperty(String key, String value) {
+		this.key = key;
+		this.value = value;
+	}
+
+	public FileProperty(String key, String value, PropertyVisibility visibility) {
+		this.key = key;
+		this.value = value;
+		this.visibility = visibility;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public PropertyVisibility getVisibility() {
+		return visibility;
+	}
+
+	public void setVisibility(PropertyVisibility visibility) {
+		this.visibility = visibility;
+	}
+	
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/PropertyVisibility.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/PropertyVisibility.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.drive;
+
+/**
+ * Enum representing the visibility of a custom property (PUBLIC or PRIVATE)
+ * @author Gabriel Axel
+ */
+public enum PropertyVisibility {
+
+	PUBLIC, PRIVATE
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/DriveTemplate.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/DriveTemplate.java
@@ -20,6 +20,7 @@ import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 import static org.springframework.social.google.api.drive.DriveFile.FOLDER;
 import static org.springframework.util.StringUtils.hasText;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.core.io.Resource;
@@ -36,6 +37,7 @@ import org.springframework.social.google.api.drive.DriveOperations;
 import org.springframework.social.google.api.drive.FileComment;
 import org.springframework.social.google.api.drive.FileCommentQueryBuilder;
 import org.springframework.social.google.api.drive.FileCommentsPage;
+import org.springframework.social.google.api.drive.FileProperty;
 import org.springframework.social.google.api.drive.FileRevision;
 import org.springframework.social.google.api.drive.UploadParameters;
 import org.springframework.social.google.api.drive.UserPermission;
@@ -67,6 +69,8 @@ public class DriveTemplate extends AbstractGoogleApiOperations implements
 	private static final String COMMENTS = "/comments/";
 	
 	private static final String REPLIES = "/replies/";
+	
+	private static final String PROPERTIES = "/properties/";
 	
 	private static final String SEND_NOTIFICATION = "?sendNotificationEmails=";
 	
@@ -293,5 +297,39 @@ public class DriveTemplate extends AbstractGoogleApiOperations implements
 	@Override
 	public Resource downloadFile(DriveFile file) {
 		return restTemplate.getForObject(file.getDownloadUrl(), Resource.class);
+	}
+
+	@Override
+	public List<FileProperty> getProperties(String fileId)
+	{
+		return getEntity(DRIVE_FILES_URL + fileId + PROPERTIES, FilePropertiesList.class).getItems();
+	}
+
+	@Override
+	public FileProperty getProperty(String fileId, String propertyKey)
+	{
+		return getEntity(DRIVE_FILES_URL + fileId + PROPERTIES + propertyKey, FileProperty.class);
+	}
+
+	@Override
+	public FileProperty addProperty(String fileId, FileProperty property)
+	{
+		return saveEntity(DRIVE_FILES_URL + fileId + PROPERTIES, property);
+	}
+
+	@Override
+	public FileProperty updateProperty(String fileId, FileProperty property)
+	{
+		Object patch = new PatchBuilder()
+			.set("value", property.getValue())
+			.set("visibility", property.getVisibility())
+			.getMap();
+		return patch(DRIVE_FILES_URL + fileId + PROPERTIES + property.getKey(), patch, FileProperty.class);
+	}
+
+	@Override
+	public void removeProperty(String fileId, String propertyKey)
+	{
+		restTemplate.delete(DRIVE_FILES_URL + fileId + PROPERTIES + propertyKey);
 	}
 }

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/FilePropertiesList.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/FilePropertiesList.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.drive.impl;
+
+import org.springframework.social.google.api.drive.FileProperty;
+import org.springframework.social.google.api.query.ApiList;
+
+/**
+ * {@link ApiList} of {@link FileProperty}
+ * @author Will Abson
+ */
+class FilePropertiesList extends ApiList<FileProperty> {
+
+}


### PR DESCRIPTION
Custom properties are a powerful way of setting custom application or user-specific metadata on files, which can then be [queried](https://developers.google.com/drive/web/search-parameters) via the Drive API.

This pull request implements support for setting/fetching/deleting custom properties against a specific file in addition to supporting querying for specific property values via `DriveFileQueryBuilder`.