### PR TITLE
Support copying and moving files stored within Drive

### DIFF
--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveFile.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveFile.java
@@ -63,7 +63,7 @@ public class DriveFile extends ApiEntity {
 
 		private Collection<String> parentIds = new HashSet<String>();
 
-		private Builder() {
+		public Builder() {
 		}
 
 		public Builder setTitle(String title) {

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveFileParent.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveFileParent.java
@@ -31,7 +31,7 @@ public class DriveFileParent {
 	public DriveFileParent() {
 	}
 	
-	DriveFileParent(String id) {
+	public DriveFileParent(String id) {
 		this.id = id;
 	}
 	

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveOperations.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveOperations.java
@@ -180,6 +180,30 @@ public interface DriveOperations {
 	DriveFile copy(String id);
 
 	/**
+	 * Create a copy of a file
+	 * 
+	 * @param id
+	 *            The ID of the source file
+	 * @param parentIds
+	 *            Array of parent folder ID to place the file into, or "root"
+	 * @return The newly-created {@link DriveFile} copy
+	 */
+	DriveFile copy(String id, String[] parentIds);
+
+	/**
+	 * Create a copy of a file
+	 * 
+	 * @param id
+	 *            The ID of the source file
+	 * @param parentIds
+	 *            Array of parent folder ID to place the file into, or "root"
+	 * @param title
+	 *            The title to apply to the new file
+	 * @return The newly-created {@link DriveFile} copy
+	 */
+	DriveFile copy(String id, String[] parentIds, String title);
+
+	/**
 	 * Move a file into a different folder
 	 * 
 	 * @param id

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveOperations.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveOperations.java
@@ -169,6 +169,15 @@ public interface DriveOperations {
 	 *            The ID of the file to delete
 	 */
 	void delete(String id);
+	
+	/**
+	 * Create a copy of a file
+	 * 
+	 * @param id
+	 *            The ID of the source file
+	 * @return The newly-created {@link DriveFile} copy
+	 */
+	DriveFile copy(String id);
 
 	/**
 	 * Move a file into a different folder

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveOperations.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveOperations.java
@@ -171,6 +171,17 @@ public interface DriveOperations {
 	void delete(String id);
 
 	/**
+	 * Move a file into a different folder
+	 * 
+	 * @param id
+	 *            The ID of the file to move
+	 * @param parentId
+	 *            The parent folder ID to move the file to, or "root"
+	 * @return The updated {@link DriveFile}
+	 */
+	DriveFile move(String id, String parentId);
+
+	/**
 	 * Uploads a file using multipart
 	 * 
 	 * @param resource

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/DriveTemplate.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/DriveTemplate.java
@@ -161,6 +161,11 @@ public class DriveTemplate extends AbstractGoogleApiOperations implements
 	}
 
 	@Override
+	public DriveFile copy(String id) {
+		return restTemplate.postForObject(DRIVE_FILES_URL + id + "/copy", null, DriveFile.class);
+	}
+
+	@Override
 	public DriveFile move(String id, String parentId) {
 		List<DriveFileParent> parents = new ArrayList<DriveFileParent>(1);
 		parents.add(new DriveFileParent(parentId));

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/DriveTemplate.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/DriveTemplate.java
@@ -166,6 +166,23 @@ public class DriveTemplate extends AbstractGoogleApiOperations implements
 	}
 
 	@Override
+	public DriveFile copy(String id, String[] parentIds) {
+		DriveFile file = new DriveFile.Builder()
+		.setParents(parentIds)
+		.build();
+		return saveEntity(DRIVE_FILES_URL + id + "/copy", file);
+	}
+
+	@Override
+	public DriveFile copy(String id, String[] parentIds, String title) {
+		DriveFile file = new DriveFile.Builder()
+		.setTitle(title)
+		.setParents(parentIds)
+		.build();
+		return saveEntity(DRIVE_FILES_URL + id + "/copy", file);
+	}
+
+	@Override
 	public DriveFile move(String id, String parentId) {
 		List<DriveFileParent> parents = new ArrayList<DriveFileParent>(1);
 		parents.add(new DriveFileParent(parentId));

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/DriveTemplate.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/drive/impl/DriveTemplate.java
@@ -30,6 +30,7 @@ import org.springframework.social.google.api.drive.CommentReply;
 import org.springframework.social.google.api.drive.DriveAbout;
 import org.springframework.social.google.api.drive.DriveApp;
 import org.springframework.social.google.api.drive.DriveFile;
+import org.springframework.social.google.api.drive.DriveFileParent;
 import org.springframework.social.google.api.drive.DriveFileQueryBuilder;
 import org.springframework.social.google.api.drive.DriveFilesPage;
 import org.springframework.social.google.api.drive.DriveOperations;
@@ -157,6 +158,13 @@ public class DriveTemplate extends AbstractGoogleApiOperations implements
 	@Override
 	public void delete(String id) {
 		restTemplate.delete(DRIVE_FILES_URL + id);
+	}
+
+	@Override
+	public DriveFile move(String id, String parentId) {
+		List<DriveFileParent> parents = new ArrayList<DriveFileParent>(1);
+		parents.add(new DriveFileParent(parentId));
+		return patch(DRIVE_FILES_URL + id, new PatchBuilder().set("parents", parents).getMap(), DriveFile.class);
 	}
 
 	@Override


### PR DESCRIPTION
This pull request enables existing files stored within Drive to be copied to the same or a different folder location, with a different name if desired. The move support sets the `parentId` property on an existing file which has the effect of moving it into the folder identified by that ID.