### PR TITLE
Fixing compile errors

### DIFF
--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/CalendarOperations.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/CalendarOperations.java
@@ -17,18 +17,20 @@ package org.springframework.social.google.api.calendar;
 
 /**
  * Interface defining operations for integrating with Google Calendar.
- * <p>See the reference documentation at
+ * 
+ * See the reference documentation at
  * <a href="http://developers.google.com/google-apps/calendar/v3/reference/">
- * http://developers.google.com/google-apps/calendar/v3/reference/</a>.</p>
- * <p>Requires one of the following OAuth scope(s):
- * <ul>
- * <li>https://www.googleapis.com/auth/calendar.readonly</li>
- * <li>https://www.googleapis.com/auth/calendar</li>
- * </ul>
+ * http://developers.google.com/google-apps/calendar/v3/reference/</a>.
+ * <br>
+ * Requires one of the following OAuth scope(s):
+ *   <ul>
+ *      <li>https://www.googleapis.com/auth/calendar.readonly</li>
+ *      <li>https://www.googleapis.com/auth/calendar</li>
+ *  </ul>
  * See
- * <a href="http://developers.google.com/google-apps/calendar/auth">
- * http://developers.google.com/google-apps/calendar/auth</a>
- * for details about the different scopes.</p>
+ * <a href="http://developers.google.com/google-apps/calendar/auth">http://developers.google.com/google-apps/calendar/auth</a>
+ * for details about the different scopes.
+ * 
  * 
  * @author Martin Wink
  */

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Event.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/calendar/Event.java
@@ -218,7 +218,7 @@ public class Event extends ApiEntity {
 		/**
 		 * Set the time zone in which the time is specified (e.g. "Europe/Zurich").
 		 * The time zone is required for recurring events.
-		 * @param date the new value or {@code null} if none.
+		 * @param timeZone the new value or {@code null} if none.
 		 * @return this {@link DateTimeTimezone}, for chaining.
 		 */
 		public DateTimeTimezone setTimeZone(TimeZone timeZone) {

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/query/impl/QueryBuilderImpl.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/query/impl/QueryBuilderImpl.java
@@ -23,8 +23,10 @@ import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TimeZone;
 
 import org.springframework.social.google.api.query.QueryBuilder;
 
@@ -36,10 +38,16 @@ import org.springframework.social.google.api.query.QueryBuilder;
  */
 public abstract class QueryBuilderImpl<Q extends QueryBuilder<?, T>, T> implements QueryBuilder<Q, T> {
 
-	private static final Format dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+	private static final Format dateFormatter;
+        
+        static {
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+            dateFormatter = simpleDateFormat;
+        }
 	
 	protected String feedUrl;
-	private Map<String, String> params = new HashMap<String, String>();	
+	private Map<String, String> params = new LinkedHashMap<String, String>();	
 	
 	protected static String encode(String text) {
 		try {

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_CalendarUrlTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_CalendarUrlTests.java
@@ -167,7 +167,7 @@ public class CalendarTemplate_CalendarUrlTests extends AbstractGoogleApiTest {
 				.andRespond(
 						withSuccess(jsonResource("mock_get_calendar_primary"), APPLICATION_JSON));
 
-		Calendar cal = google.calendarOperations().getCalendar("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?");
+		Calendar cal = google.calendarOperations().getCalendar("abc123!\"Â£$%^&*()_+-=[]{};'#:@~,./<>?");
 
 		assertNotNull(cal);
 		// NB queried for "primary" but actually get back the real ID.

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_EventUrlTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_EventUrlTests.java
@@ -96,7 +96,7 @@ public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
 
 		EventPage eventPage = google.calendarOperations()
 				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
-				.fromPage("abc123_¬!£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.fromPage("abc123_Â¬!Â£$%^&*()_+-=[]{};'#:@~,./<>?")
 				.getPage();
 
 		assertNotNull(eventPage);
@@ -436,18 +436,18 @@ public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
 
 		EventPage eventPage = google.calendarOperations()
 				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
-				.fromPage("pretendPageToken")
-				.alwaysIncludeEmail(true)
-				.iCalUID("test-iCalUID")
-				.maxAttendees(9)
-				.maxResultsNumber(50)
-				.orderBy(OrderBy.START_TIME)
+                                .alwaysIncludeEmail(true)
+        			.orderBy(OrderBy.START_TIME)
+				.timeZone(TEST_TIMEZONE)	
+                                .fromPage("pretendPageToken")
+				.singleEvents(true)	
+                                .showHiddenInvitations(true)
+				.maxResultsNumber(50)	
+                                .maxAttendees(9)
+                                .timeMin(TEST_TIME_MIN)
+                                .iCalUID("test-iCalUID")
 				.showDeleted(true)
-				.showHiddenInvitations(true)
-				.singleEvents(true)
-				.timeMax(TEST_TIME_MAX)
-				.timeMin(TEST_TIME_MIN)
-				.timeZone(TEST_TIMEZONE)
+                                .timeMax(TEST_TIME_MAX)	
 				.updatedMin(TEST_UPDATED_MIN)
 				.getPage();
 
@@ -464,7 +464,7 @@ public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
 				withSuccess(jsonResource("mock_get_event"), APPLICATION_JSON));
 
 		EventPage eventPage = google.calendarOperations()
-				.eventListQuery("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.eventListQuery("abc123!\"Â£$%^&*()_+-=[]{};'#:@~,./<>?")
 				.getPage();
 
 		assertNotNull(eventPage);
@@ -480,8 +480,8 @@ public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
 				withSuccess(jsonResource("mock_list_events_empty"), APPLICATION_JSON));
 
 		EventPage eventPage = google.calendarOperations()
-				.eventListQuery("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?")
-				.fromPage("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.eventListQuery("abc123!\"Â£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.fromPage("abc123!\"Â£$%^&*()_+-=[]{};'#:@~,./<>?")
 				.getPage();
 		
 		assertNotNull(eventPage);
@@ -512,7 +512,7 @@ public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
 				.andRespond(
 						withSuccess(jsonResource("mock_get_event"), APPLICATION_JSON));
 
-		Event event = google.calendarOperations().getEvent("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?", "abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?");
+		Event event = google.calendarOperations().getEvent("abc123!\"Â£$%^&*()_+-=[]{};'#:@~,./<>?", "abc123!\"Â£$%^&*()_+-=[]{};'#:@~,./<>?");
 
 		assertNotNull(event);
 	}


### PR DESCRIPTION
See the comments in the commits.

Additionally the query builder probably needs to be transitioned to using Calendar Objects instead of Date objects.  Date Objects lack time zone information.