### PR TITLE
Spring Boot Autoconfiguration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .project
 .settings
 .DS_Store
+*.iml
+/.idea/
 build
 **/build
 **/src/test/java/exploration

--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,11 @@ configure(allprojects) {
 
     group = 'org.springframework.social'
 
-    sourceCompatibility=1.6
-    targetCompatibility=1.6
+    sourceCompatibility = 1.6
+    targetCompatibility = 1.6
 
     ext {
+        springBootVersion = '1.2.6.RELEASE'
         springSocialVersion = '1.1.0.RELEASE'
         jacksonVersion = '2.3.3'
         junitVersion = '4.11'
@@ -40,9 +41,9 @@ configure(allprojects) {
     }
 
     dependencies {
-        testCompile "junit:junit:$junitVersion"
-        testCompile "org.mockito:mockito-all:$mockitoVersion"
-        testCompile "org.springframework:spring-test:$springVersion"
+        testCompile("junit:junit:$junitVersion")
+        testCompile("org.mockito:mockito-all:$mockitoVersion")
+        testCompile("org.springframework:spring-test:$springVersion")
     }
 
     // servlet-api (2.5) and tomcat-servlet-api (3.0) classpath entries should not be
@@ -75,7 +76,7 @@ configure(subprojects) { subproject ->
         //options.overview = "${projectDir}/src/main/java/overview.html"
     }
 
-    task sourcesJar(type: Jar, dependsOn:classes) {
+    task sourcesJar(type: Jar, dependsOn: classes) {
         classifier = 'sources'
         from sourceSets.main.allJava
     }
@@ -94,14 +95,18 @@ configure(subprojects) { subproject ->
 project('spring-social-google') {
     description = 'Google API'
     dependencies {
-       compile "org.springframework.social:spring-social-core:$springSocialVersion"
-       compile ("org.springframework.social:spring-social-config:$springSocialVersion")
-       compile ("org.springframework.social:spring-social-security:$springSocialVersion", optional)
-       compile ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
-       compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-       compile ("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
-       compile ("javax.servlet:javax.servlet-api:$servletApiVersion", provided)
-       testCompile "org.springframework:spring-test:$springVersion"
+        compile("org.springframework.boot:spring-boot-starter:$springBootVersion", optional)
+        compile("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion", optional)
+
+        compile("org.springframework.social:spring-social-core:$springSocialVersion")
+        compile("org.springframework.social:spring-social-config:$springSocialVersion")
+        compile("org.springframework.social:spring-social-security:$springSocialVersion", optional)
+        compile("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
+        compile("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+        compile("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
+        compile("javax.servlet:javax.servlet-api:$servletApiVersion", provided)
+
+        testCompile "org.springframework:spring-test:$springVersion"
     }
 }
 
@@ -119,7 +124,7 @@ configure(rootProject) {
 
     dependencies { // for integration tests
     }
-    
+
     task api(type: Javadoc) {
         group = 'Documentation'
         description = 'Generates aggregated Javadoc API documentation.'
@@ -129,7 +134,7 @@ configure(rootProject) {
         options.header = rootProject.description
         options.overview = 'src/api/overview.html'
         options.links(
-            'http://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
+                'http://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
         )
         source subprojects.collect { project ->
             project.sourceSets.main.allJava
@@ -145,17 +150,17 @@ configure(rootProject) {
         group = 'Distribution'
         classifier = 'docs'
         description = "Builds -${classifier} archive containing api and reference " +
-            "for deployment at static.springframework.org/spring-social/docs."
+                "for deployment at static.springframework.org/spring-social/docs."
 
         from('src/dist') {
             include 'changelog.txt'
         }
 
-        from (api) {
+        from(api) {
             into 'api'
         }
 
-        from (reference) {
+        from(reference) {
             into 'reference'
         }
     }
@@ -164,7 +169,7 @@ configure(rootProject) {
         group = 'Distribution'
         classifier = 'schema'
         description = "Builds -${classifier} archive containing all " +
-            "XSDs for deployment at static.springframework.org/schema."
+                "XSDs for deployment at static.springframework.org/schema."
 
         subprojects.each { subproject ->
             def Properties schemas = new Properties();
@@ -180,7 +185,7 @@ configure(rootProject) {
                     it.path.endsWith(schemas.get(key))
                 }
                 assert xsdFile != null
-                into (shortName) {
+                into(shortName) {
                     from xsdFile.path
                 }
             }
@@ -191,7 +196,7 @@ configure(rootProject) {
         group = 'Distribution'
         classifier = 'dist'
         description = "Builds -${classifier} archive, containing all jars and docs, " +
-                      "suitable for community download page."
+                "suitable for community download page."
 
         ext.baseDir = "${project.name}-${project.version}";
 
@@ -212,7 +217,7 @@ configure(rootProject) {
         }
 
         subprojects.each { subproject ->
-            into ("${baseDir}/libs") {
+            into("${baseDir}/libs") {
                 from subproject.jar
                 if (subproject.tasks.findByPath('sourcesJar')) {
                     from subproject.sourcesJar

--- a/spring-social-google/src/main/java/META-INF/MANIFEST.MF
+++ b/spring-social-google/src/main/java/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Class-Path: 
-
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.springframework.social.google.config.boot.GoogleAutoConfiguration

--- a/spring-social-google/src/main/java/org/springframework/social/google/config/boot/GoogleAutoConfiguration.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/config/boot/GoogleAutoConfiguration.java
@@ -1,0 +1,72 @@
+package org.springframework.social.google.config.boot;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.social.SocialWebAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.core.env.Environment;
+import org.springframework.social.config.annotation.ConnectionFactoryConfigurer;
+import org.springframework.social.config.annotation.EnableSocial;
+import org.springframework.social.config.annotation.SocialConfigurerAdapter;
+import org.springframework.social.connect.Connection;
+import org.springframework.social.connect.ConnectionRepository;
+import org.springframework.social.connect.web.GenericConnectionStatusView;
+import org.springframework.social.google.api.Google;
+import org.springframework.social.google.connect.GoogleConnectionFactory;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Social connectivity with Google.
+ *
+ * @author Leon Radley
+ * @since 1.0.1
+ */
+@Configuration
+@ConditionalOnClass({ SocialConfigurerAdapter.class, GoogleConnectionFactory.class })
+@ConditionalOnProperty(prefix = "spring.social.google", name = "app-id")
+@AutoConfigureBefore(SocialWebAutoConfiguration.class)
+@AutoConfigureAfter(WebMvcAutoConfiguration.class)
+public class GoogleAutoConfiguration {
+
+    @Configuration
+    @EnableSocial
+    @EnableConfigurationProperties(GoogleProperties.class)
+    @ConditionalOnWebApplication
+    protected static class GoogleConfigurerAdapter extends SocialConfigurerAdapter {
+
+        @Autowired
+        private GoogleProperties properties;
+
+        @Bean
+        @ConditionalOnMissingBean
+        @Scope(value = "request", proxyMode = ScopedProxyMode.INTERFACES)
+        public Google google(ConnectionRepository repository) {
+            Connection<Google> connection = repository.findPrimaryConnection(Google.class);
+            return connection != null ? connection.getApi() : null;
+        }
+
+        @Bean(name = { "connect/googleConnect", "connect/googleConnected" })
+        @ConditionalOnProperty(prefix = "spring.social", name = "auto-connection-views")
+        public GenericConnectionStatusView googleConnectView() {
+            return new GenericConnectionStatusView("google", "Google");
+        }
+
+        @Override
+        public void addConnectionFactories(ConnectionFactoryConfigurer configurer, Environment environment) {
+            GoogleConnectionFactory factory = new GoogleConnectionFactory(this.properties.getAppId(), this.properties.getAppSecret());
+            factory.setScope("email profile");
+            configurer.addConnectionFactory(factory);
+        }
+    }
+
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/config/boot/GoogleProperties.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/config/boot/GoogleProperties.java
@@ -1,0 +1,32 @@
+package org.springframework.social.google.config.boot;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.social.google")
+public class GoogleProperties {
+    /**
+     * Application id.
+     */
+    private String appId;
+
+    /**
+     * Application secret.
+     */
+    private String appSecret;
+
+    public String getAppId() {
+        return this.appId;
+    }
+
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    public String getAppSecret() {
+        return this.appSecret;
+    }
+
+    public void setAppSecret(String appSecret) {
+        this.appSecret = appSecret;
+    }
+}


### PR DESCRIPTION
Instead of moving this, @dsyer and @wilkinsona suggested that we create the auto configuration classes directly to the repo.
That way as soon as you add the spring-social-google, it will automatically work, instead of having to add the connection factory manually