### PR TITLE
Fix issue with missing schema zip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,8 +170,8 @@ configure(rootProject) {
             def Properties schemas = new Properties();
 
             subproject.sourceSets.main.resources.find {
-                it.path.endsWith('META-INF/spring.schemas')
                 println "found resource: ${it.path}"
+                it.path.endsWith('META-INF/spring.schemas')
             }?.withInputStream { schemas.load(it) }
 
             for (def key : schemas.keySet()) {


### PR DESCRIPTION
There's an issue with missing schema zip during building the `develop` branch:

```
FAILURE: Build failed with an exception.

* What went wrong:
Cannot expand ZIP '.../spring-social-google/build/distributions/spring-social-google-1.0.1.BUILD-SNAPSHOT-schema.zip' as it does not exist.
```
This is because `it.path.endsWith('META-INF/spring.schemas')` must be the last statement of the find method. 

@mlaccetti: This is probably for you.