### PR TITLE
Add ageRange, language and verified fields to a person profile

### DIFF
--- a/spring-social-google/src/main/java/org/springframework/social/google/api/plus/AgeRange.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/plus/AgeRange.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2011-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.plus;
+
+/**
+ * Enum representing a user's age range.
+ * Valid ranges are 17 or younger, 18 to 20, and 21 or older.
+ *
+ * @author Michal Szwed
+ */
+public enum AgeRange {
+	UNKNOWN(null, null),
+	AGE_17_MINUS(null, 17),
+	AGE_18_20(18, 20),
+	AGE_21_PLUS(21, null);
+
+	private Integer min;
+	private Integer max;
+
+	AgeRange(Integer min, Integer max) {
+		this.min = min;
+		this.max = max;
+	}
+
+	/**
+	 * @return The minimum integer value for the range (possibly null).
+	 */
+	public Integer getMin() {
+		return min;
+	}
+
+	/**
+	 * @return The maximum integer value for the range (possibly null).
+	 */
+	public Integer getMax() {
+		return max;
+	}
+
+	/**
+	 * Constructs an AgeRange from the min/max age values.
+	 *
+	 * @param min The minimum age
+	 * @param max The maximum age
+	 * @return an AgeRange
+	 */
+	public static AgeRange fromMinMax(Integer min, Integer max) {
+		if (min == null && max == 17) {
+			return AGE_17_MINUS;
+		} else if (min == 18 && max == 20) {
+			return AGE_18_20;
+		} else if (min == 21 && max == null) {
+			return AGE_21_PLUS;
+		}
+
+		AgeRange unknown = AgeRange.UNKNOWN;
+		unknown.min = min;
+		unknown.max = max;
+		return unknown;
+	}
+}

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/plus/Person.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/plus/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,15 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.springframework.social.google.api.ApiEntity;
+import org.springframework.social.google.api.plus.impl.AgeRangeDeserializer;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Model class representing a full Google profile
- * 
+ *
  * @author Gabriel Axel
  */
 public class Person extends ApiEntity {
@@ -73,7 +75,7 @@ public class Person extends ApiEntity {
 	private String displayName;
 
 	private String url;
-	
+
 	@JsonProperty("isPlusUser")
 	private boolean plusUser;
 
@@ -99,6 +101,14 @@ public class Person extends ApiEntity {
 	private Map<String, Boolean> placesLived;
 
 	private Map<String, String> emails;
+
+	@JsonProperty
+	@JsonDeserialize(using = AgeRangeDeserializer.class)
+	private AgeRange ageRange = AgeRange.UNKNOWN;
+
+	private String language;
+
+	private Boolean verified;
 
 	@Override
 	public String toString() {
@@ -140,7 +150,7 @@ public class Person extends ApiEntity {
 	public String getUrl() {
 		return url;
 	}
-	
+
 	public boolean isPlusUser() {
 		return plusUser;
 	}
@@ -205,4 +215,16 @@ public class Person extends ApiEntity {
 		}
 		return null;
 	}
+
+	public AgeRange getAgeRange() {
+		return ageRange;
+	}
+
+	public String getLanguage() {
+		return language;
+	}
+
+	public Boolean isVerified() {
+        return verified;
+    }
 }

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/plus/impl/AgeRangeDeserializer.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/plus/impl/AgeRangeDeserializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2011-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.plus.impl;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.springframework.social.google.api.plus.AgeRange;
+
+/**
+ * @author Michal Szwed
+ */
+public class AgeRangeDeserializer extends JsonDeserializer<AgeRange> {
+
+	@Override
+	public AgeRange deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+		JsonNode ageRangeNode = jp.readValueAs(JsonNode.class);
+		JsonNode minNode = ageRangeNode.get("min");
+		JsonNode maxNode = ageRangeNode.get("max");
+		Integer min = minNode != null ? minNode.asInt() : null;
+		Integer max = maxNode != null ? maxNode.asInt() : null;
+
+		return AgeRange.fromMinMax(min, max);
+	}
+}

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/plus/PlusTemplateTest.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/plus/PlusTemplateTest.java
@@ -309,6 +309,9 @@ public class PlusTemplateTest extends AbstractGoogleApiTest {
 		assertEquals(expectedPlacesLived, person.getPlacesLived());
 		assertEquals("guznik@gmail.com", person.getAccountEmail());
 		assertEquals("https://plus.google.com/+GabrielAxel", person.getUrl());
+		assertEquals(AgeRange.AGE_21_PLUS, person.getAgeRange());
+		assertEquals("en", person.getLanguage());
+		assertTrue(person.isVerified());
 		assertTrue(person.isPlusUser());
 	}
 }

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/plus/person.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/plus/person.json
@@ -5,7 +5,7 @@
   }, 
   "id": "114863353858610846998", 
   "objectType": "person", 
-  "verified": false, 
+  "verified": true, 
   "etag": "\"YFr-hUROXQN7IOa3dUHg9dQ8eq0/NEVHKJoN067kdVmOajomyD-wN6Y\"", 
   "circledByCount": 51, 
   "occupation": "Software Engineer", 


### PR DESCRIPTION
I added fields to `Person` which I think are common used.

Implementation of `AgeRange` is based on `spring-social-facebook` approach with values adjusted to  Google API (based documentation from Google): `The age range of the person. Valid ranges are 17 or younger, 18 to 20, and 21 or older. Age is determined from the user's birthday using Western age reckoning.`. In the worse case other values are accepted as well as `UNKNOWN`.

`language` is documented as String, so I think it should be fine, `verified` is boolean, but might be also `null`.