### PR TITLE
Issue#85 - Made fixes for Windows builds using gradle wrapper.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/AbstractGoogleApiTest.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/AbstractGoogleApiTest.java
@@ -15,12 +15,15 @@
  */
 package org.springframework.social.google.api;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+import org.json.JSONObject;
 import org.junit.Before;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -60,5 +63,15 @@ public class AbstractGoogleApiTest {
 		} catch (ParseException e) {
 			throw new IllegalArgumentException(e);
 		}
+	}
+
+	protected String encodeUTF8(String textToEncode) throws UnsupportedEncodingException {
+
+		return URLEncoder.encode(textToEncode, "UTF-8");
+	}
+
+	protected String normalizeJsonObjectLineFeeds(String fileJsonString) {
+
+		return new JSONObject(fileJsonString).toString();
 	}
 }

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_CalendarUrlTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_CalendarUrlTests.java
@@ -26,6 +26,9 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import org.junit.Test;
 import org.springframework.social.google.api.AbstractGoogleApiTest;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 public class CalendarTemplate_CalendarUrlTests extends AbstractGoogleApiTest {
 
 	@Test
@@ -159,15 +162,19 @@ public class CalendarTemplate_CalendarUrlTests extends AbstractGoogleApiTest {
 	}
 
 	@Test
-	public void getCalendar_escaped() {
+	public void getCalendar_escaped() throws UnsupportedEncodingException {
+
+		String calendarId = "abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?";
+
+		String encodedCalendarId = URLEncoder.encode(calendarId, "UTF-8");
 
 		mockServer
-				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F"))
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/users/me/calendarList/" + encodedCalendarId))
 				.andExpect(method(GET))
 				.andRespond(
 						withSuccess(jsonResource("mock_get_calendar_primary"), APPLICATION_JSON));
 
-		Calendar cal = google.calendarOperations().getCalendar("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?");
+		Calendar cal = google.calendarOperations().getCalendar(calendarId);
 
 		assertNotNull(cal);
 		// NB queried for "primary" but actually get back the real ID.

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_EventUrlTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/CalendarTemplate_EventUrlTests.java
@@ -27,6 +27,8 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -86,17 +88,19 @@ public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
 	}
 
 	@Test
-	public void listEvents_primary_fromPage_escaping() {
+	public void listEvents_primary_fromPage_escaping() throws UnsupportedEncodingException {
+
+		String pageToken = "abc123_¬!£$%^&*()_+-=[]{};'#:@~,./<>?";
 
 		mockServer
-				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?pageToken=abc123_%C2%AC%21%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F"))
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/primary/events?pageToken=" + encodeUTF8(pageToken)))
 				.andExpect(method(GET))
 				.andRespond(
 						withSuccess(jsonResource("mock_list_events"), APPLICATION_JSON));
 
 		EventPage eventPage = google.calendarOperations()
 				.eventListQuery(CalendarOperations.PRIMARY_CALENDAR_ID)
-				.fromPage("abc123_¬!£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.fromPage(pageToken)
 				.getPage();
 
 		assertNotNull(eventPage);
@@ -455,33 +459,38 @@ public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
 	}
 
 	@Test
-	public void listEvents_escape_calendarId() {
+	public void listEvents_escape_calendarId() throws UnsupportedEncodingException {
+
+		String calendarId = "abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?";
 
 		mockServer
-			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F/events"))
-			.andExpect(method(GET))
-			.andRespond(
-				withSuccess(jsonResource("mock_get_event"), APPLICATION_JSON));
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/" + encodeUTF8(calendarId) + "/events"))
+				.andExpect(method(GET))
+				.andRespond(
+						withSuccess(jsonResource("mock_get_event"), APPLICATION_JSON));
 
 		EventPage eventPage = google.calendarOperations()
-				.eventListQuery("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.eventListQuery(calendarId)
 				.getPage();
 
 		assertNotNull(eventPage);
 	}
 
 	@Test
-	public void listEvents_escape_pageToken() {
+	public void listEvents_escape_pageToken() throws UnsupportedEncodingException {
+
+		String calendarId = "abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?";
+		String pageToken = "abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?";
 
 		mockServer
-			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F/events?pageToken=abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F"))
+			.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/" + encodeUTF8(calendarId) + "/events?pageToken=" + encodeUTF8(pageToken)))
 			.andExpect(method(GET))
 			.andRespond(
-				withSuccess(jsonResource("mock_list_events_empty"), APPLICATION_JSON));
+					withSuccess(jsonResource("mock_list_events_empty"), APPLICATION_JSON));
 
 		EventPage eventPage = google.calendarOperations()
-				.eventListQuery("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?")
-				.fromPage("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?")
+				.eventListQuery(calendarId)
+				.fromPage(pageToken)
 				.getPage();
 		
 		assertNotNull(eventPage);
@@ -504,15 +513,18 @@ public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
 	}
 
 	@Test
-	public void getEvent_escape_calendarId() {
+	public void getEvent_escape_calendarId() throws UnsupportedEncodingException {
+
+		String calendarId = "abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?";
+		String eventId = "abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?";
 
 		mockServer
-				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F/events/abc123%21%22%C2%A3%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%3B%27%23%3A%40%7E%2C.%2F%3C%3E%3F"))
+				.expect(requestTo("https://www.googleapis.com/calendar/v3/calendars/" + encodeUTF8(calendarId) + "/events/" + encodeUTF8(eventId)))
 				.andExpect(method(GET))
 				.andRespond(
 						withSuccess(jsonResource("mock_get_event"), APPLICATION_JSON));
 
-		Event event = google.calendarOperations().getEvent("abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?", "abc123!\"£$%^&*()_+-=[]{};'#:@~,./<>?");
+		Event event = google.calendarOperations().getEvent(calendarId, eventId);
 
 		assertNotNull(event);
 	}
@@ -561,4 +573,5 @@ public class CalendarTemplate_EventUrlTests extends AbstractGoogleApiTest {
 
 		google.calendarOperations().updateEvent("primary", event, true);
 	}
+
 }

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/EventModificationTests.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/calendar/EventModificationTests.java
@@ -1,237 +1,1 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.springframework.social.google.api.calendar;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.TimeZone;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.springframework.social.google.api.AbstractGoogleApiTest;
-import org.springframework.social.google.api.calendar.Event.DateTimeTimezone;
-import org.springframework.util.StreamUtils;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
-/**
- * Tests to verify that the Event JSON is correctly updated through the Event class.
- * @author Martin Wink
- */
-public class EventModificationTests extends AbstractGoogleApiTest {
-
-	@Rule
-	public TemporaryFolder folder = new TemporaryFolder();
-	
-	private File originalFile;
-	private File newFile;
-	private ObjectMapper mapper;
-	private Event event;
-
-	@Before
-	public void createTestData() throws IOException {
-		originalFile = jsonResource("pre_modification_event").getFile();
-		newFile = folder.newFile();
-		mapper = new ObjectMapper();
-		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);	// kind etc not used in Event.
-		mapper.configure(SerializationFeature.INDENT_OUTPUT, true);	// So output matches expected formatting.
-		event = mapper.readValue(originalFile, Event.class);
-	}
-
-	@After
-	public void cleanUp() {
-	}
-
-	private String loadFileToString(File file) throws IOException, FileNotFoundException {
-		return StreamUtils.copyToString(new FileInputStream(file), Charset.defaultCharset());
-	}
-	
-	private String loadJsonResourceToString(String name) throws FileNotFoundException, IOException {
-		return loadFileToString(jsonResource(name).getFile());
-	}
-
-	@Test
-	public void verify_unmodified() throws JsonParseException, JsonMappingException, IOException {
-		mapper.writeValue(newFile, event);
-		assertEquals(loadJsonResourceToString("post_unmodified_event"), loadFileToString(newFile));
-	}
-
-	@Test
-	public void set_null_values() throws JsonParseException, JsonMappingException, IOException {
-		event.setGuestsCanInviteOthers(null);
-		assertEquals(null, event.isGuestsCanInviteOthers());
-
-		event.setGuestsCanSeeOtherGuests(null);
-		assertEquals(null, event.isGuestsCanSeeOtherGuests());
-
-		event.setLocation(null);
-		assertEquals(null, event.getLocation());
-
-		event.setStatus(null);
-		assertEquals(null, event.getStatus());
-
-		event.setSummary(null);
-		assertEquals(null, event.getSummary());
-
-		final DateTimeTimezone start = event.getStart();
-		start.setDate(null);
-		assertNull(start.getDate());
-
-		start.setDateTime(null);
-		assertNull(start.getDateTime());
-
-		start.setTimeZone(null);
-		assertNull(start.getTimeZone());
-
-		final DateTimeTimezone end = event.getEnd();
-		end.setDate(null);
-		assertNull(end.getDate());
-
-		end.setDateTime(null);
-		assertNull(end.getDateTime());
-
-		end.setTimeZone(null);
-		assertNull(end.getTimeZone());
-		
-		event.setRecurrence(null);
-		assertNull(event.getRecurrence());
-
-		mapper.writeValue(newFile, event);
-		assertEquals(loadJsonResourceToString("post_null_values_event"), loadFileToString(newFile));
-	}
-
-	@Test
-	public void set_non_null_values_1() throws JsonParseException, JsonMappingException, IOException {
-		event.setGuestsCanInviteOthers(true);
-		assertEquals(true, event.isGuestsCanInviteOthers());
-
-		event.setGuestsCanSeeOtherGuests(false);
-		assertEquals(false, event.isGuestsCanSeeOtherGuests());
-
-		event.setLocation("Somewhere else");
-		assertEquals("Somewhere else", event.getLocation());
-
-		event.setStatus(EventStatus.CANCELLED);
-		assertEquals(EventStatus.CANCELLED, event.getStatus());
-
-		event.setSummary("New summary");
-		assertEquals("New summary", event.getSummary());
-
-		final DateTimeTimezone start = event.getStart();
-		final Date date1 = DateUtils.makeDate(2014, 11, 27);
-		start.setDate(date1);
-		assertEquals(date1, start.getDate());
-
-		final Date date2 = DateUtils.makeDate(2014, 11, 28);
-		start.setDateTime(date2);
-		assertEquals(date2, start.getDateTime());
-
-		final TimeZone timeZone1 = TimeZone.getTimeZone("UTC");
-		start.setTimeZone(timeZone1);
-		assertEquals(timeZone1, start.getTimeZone());
-
-		final DateTimeTimezone end = event.getEnd();
-		final Date date3 = DateUtils.makeDate(2014, 11, 29);
-		end.setDate(date3);
-		assertEquals(date3, end.getDate());
-
-		final Date date4 = DateUtils.makeDate(2014, 11, 30);
-		end.setDateTime(date4);
-		assertEquals(date4, end.getDateTime());
-
-		final TimeZone timeZone2 = TimeZone.getTimeZone("PST");
-		end.setTimeZone(timeZone2);
-		assertEquals(timeZone2, end.getTimeZone());
-
-		event.setRecurrence(new ArrayList<String>());
-		assertNotNull(event.getRecurrence());
-		assertEquals(0, event.getRecurrence().size());
-
-		mapper.writeValue(newFile, event);
-		assertEquals(loadJsonResourceToString("post_non_null_values_1_event"), loadFileToString(newFile));
-	}
-
-	@Test
-	public void set_non_null_values_2() throws JsonParseException, JsonMappingException, IOException {
-		event.setGuestsCanInviteOthers(false);
-		assertEquals(false, event.isGuestsCanInviteOthers());
-
-		event.setGuestsCanSeeOtherGuests(true);
-		assertEquals(true, event.isGuestsCanSeeOtherGuests());
-
-		event.setLocation("Another place");
-		assertEquals("Another place", event.getLocation());
-
-		event.setStatus(EventStatus.TENTATIVE);
-		assertEquals(EventStatus.TENTATIVE, event.getStatus());
-
-		event.setSummary("Another title");
-		assertEquals("Another title", event.getSummary());
-
-		final DateTimeTimezone start = event.getStart();
-		final Date date1 = DateUtils.makeDate(2013, 11, 27);
-		start.setDate(date1);
-		assertEquals(date1, start.getDate());
-
-		final Date date2 = DateUtils.makeDate(2013, 11, 28);
-		start.setDateTime(date2);
-		assertEquals(date2, start.getDateTime());
-
-		final TimeZone timeZone1 = TimeZone.getTimeZone("CET");
-		start.setTimeZone(timeZone1);
-		assertEquals(timeZone1, start.getTimeZone());
-
-		final DateTimeTimezone end = event.getEnd();
-		final Date date3 = DateUtils.makeDate(2013, 11, 29);
-		end.setDate(date3);
-		assertEquals(date3, end.getDate());
-
-		final Date date4 = DateUtils.makeDate(2013, 11, 30);
-		end.setDateTime(date4);
-		assertEquals(date4, end.getDateTime());
-
-		final TimeZone timeZone2 = TimeZone.getTimeZone("MST");
-		end.setTimeZone(timeZone2);
-		assertEquals(timeZone2, end.getTimeZone());
-
-		final ArrayList<String> list = new ArrayList<String>();
-		list.add("RRULE:FREQ=MONTHLY;INTERVAL=1");
-		list.add("RRULE:FREQ=MONTHLY;INTERVAL=3");
-		event.setRecurrence(list);
-		assertNotNull(event.getRecurrence());
-		assertEquals(2, event.getRecurrence().size());
-
-		mapper.writeValue(newFile, event);
-		assertEquals(loadJsonResourceToString("post_non_null_values_2_event"), loadFileToString(newFile));
-	}
-
-}
+/* * Copyright 2014 the original author or authors. * * Licensed under the Apache License, Version 2.0 (the "License"); * you may not use this file except in compliance with the License. * You may obtain a copy of the License at * *      http://www.apache.org/licenses/LICENSE-2.0 * * Unless required by applicable law or agreed to in writing, software * distributed under the License is distributed on an "AS IS" BASIS, * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. * See the License for the specific language governing permissions and * limitations under the License. */package org.springframework.social.google.api.calendar;import static org.junit.Assert.assertEquals;import static org.junit.Assert.assertNotNull;import static org.junit.Assert.assertNull;import java.io.File;import java.io.FileInputStream;import java.io.FileNotFoundException;import java.io.IOException;import java.nio.charset.Charset;import java.util.ArrayList;import java.util.Date;import java.util.TimeZone;import org.junit.After;import org.junit.Before;import org.junit.Rule;import org.junit.Test;import org.junit.rules.TemporaryFolder;import org.springframework.social.google.api.AbstractGoogleApiTest;import org.springframework.social.google.api.calendar.Event.DateTimeTimezone;import org.springframework.util.StreamUtils;import com.fasterxml.jackson.core.JsonParseException;import com.fasterxml.jackson.databind.DeserializationFeature;import com.fasterxml.jackson.databind.JsonMappingException;import com.fasterxml.jackson.databind.ObjectMapper;import com.fasterxml.jackson.databind.SerializationFeature;/** * Tests to verify that the Event JSON is correctly updated through the Event class. * @author Martin Wink */public class EventModificationTests extends AbstractGoogleApiTest {	@Rule	public TemporaryFolder folder = new TemporaryFolder();		private File originalFile;	private File newFile;	private ObjectMapper mapper;	private Event event;	@Before	public void createTestData() throws IOException {		originalFile = jsonResource("pre_modification_event").getFile();		newFile = folder.newFile();		mapper = new ObjectMapper();		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);	// kind etc not used in Event.		mapper.configure(SerializationFeature.INDENT_OUTPUT, true);	// So output matches expected formatting.		event = mapper.readValue(originalFile, Event.class);	}	@After	public void cleanUp() {	}	private String loadFileToString(File file) throws IOException, FileNotFoundException {		return StreamUtils.copyToString(new FileInputStream(file), Charset.defaultCharset());	}		private String loadJsonResourceToString(String name) throws FileNotFoundException, IOException {		return normalizeJsonObjectLineFeeds(loadFileToString(jsonResource(name).getFile()));	}	@Test	public void verify_unmodified() throws JsonParseException, JsonMappingException, IOException {        mapper.writeValue(newFile, event);		assertEquals(loadJsonResourceToString("post_unmodified_event"), normalizeJsonObjectLineFeeds(loadFileToString(newFile)));	}	@Test	public void set_null_values() throws JsonParseException, JsonMappingException, IOException {		event.setGuestsCanInviteOthers(null);		assertEquals(null, event.isGuestsCanInviteOthers());		event.setGuestsCanSeeOtherGuests(null);		assertEquals(null, event.isGuestsCanSeeOtherGuests());		event.setLocation(null);		assertEquals(null, event.getLocation());		event.setStatus(null);		assertEquals(null, event.getStatus());		event.setSummary(null);		assertEquals(null, event.getSummary());		final DateTimeTimezone start = event.getStart();		start.setDate(null);		assertNull(start.getDate());		start.setDateTime(null);		assertNull(start.getDateTime());		start.setTimeZone(null);		assertNull(start.getTimeZone());		final DateTimeTimezone end = event.getEnd();		end.setDate(null);		assertNull(end.getDate());		end.setDateTime(null);		assertNull(end.getDateTime());		end.setTimeZone(null);		assertNull(end.getTimeZone());				event.setRecurrence(null);		assertNull(event.getRecurrence());		mapper.writeValue(newFile, event);		assertEquals(loadJsonResourceToString("post_null_values_event"), normalizeJsonObjectLineFeeds(loadFileToString(newFile)));	}	@Test	public void set_non_null_values_1() throws JsonParseException, JsonMappingException, IOException {		event.setGuestsCanInviteOthers(true);		assertEquals(true, event.isGuestsCanInviteOthers());		event.setGuestsCanSeeOtherGuests(false);		assertEquals(false, event.isGuestsCanSeeOtherGuests());		event.setLocation("Somewhere else");		assertEquals("Somewhere else", event.getLocation());		event.setStatus(EventStatus.CANCELLED);		assertEquals(EventStatus.CANCELLED, event.getStatus());		event.setSummary("New summary");		assertEquals("New summary", event.getSummary());		final DateTimeTimezone start = event.getStart();		final Date date1 = DateUtils.makeDate(2014, 11, 27);		start.setDate(date1);		assertEquals(date1, start.getDate());		final Date date2 = DateUtils.makeDate(2014, 11, 28);		start.setDateTime(date2);		assertEquals(date2, start.getDateTime());		final TimeZone timeZone1 = TimeZone.getTimeZone("UTC");		start.setTimeZone(timeZone1);		assertEquals(timeZone1, start.getTimeZone());		final DateTimeTimezone end = event.getEnd();		final Date date3 = DateUtils.makeDate(2014, 11, 29);		end.setDate(date3);		assertEquals(date3, end.getDate());		final Date date4 = DateUtils.makeDate(2014, 11, 30);		end.setDateTime(date4);		assertEquals(date4, end.getDateTime());		final TimeZone timeZone2 = TimeZone.getTimeZone("PST");		end.setTimeZone(timeZone2);		assertEquals(timeZone2, end.getTimeZone());		event.setRecurrence(new ArrayList<String>());		assertNotNull(event.getRecurrence());		assertEquals(0, event.getRecurrence().size());		mapper.writeValue(newFile, event);		assertEquals(loadJsonResourceToString("post_non_null_values_1_event"), normalizeJsonObjectLineFeeds(loadFileToString(newFile)));	}	@Test	public void set_non_null_values_2() throws JsonParseException, JsonMappingException, IOException {		event.setGuestsCanInviteOthers(false);		assertEquals(false, event.isGuestsCanInviteOthers());		event.setGuestsCanSeeOtherGuests(true);		assertEquals(true, event.isGuestsCanSeeOtherGuests());		event.setLocation("Another place");		assertEquals("Another place", event.getLocation());		event.setStatus(EventStatus.TENTATIVE);		assertEquals(EventStatus.TENTATIVE, event.getStatus());		event.setSummary("Another title");		assertEquals("Another title", event.getSummary());		final DateTimeTimezone start = event.getStart();		final Date date1 = DateUtils.makeDate(2013, 11, 27);		start.setDate(date1);		assertEquals(date1, start.getDate());		final Date date2 = DateUtils.makeDate(2013, 11, 28);		start.setDateTime(date2);		assertEquals(date2, start.getDateTime());		final TimeZone timeZone1 = TimeZone.getTimeZone("CET");		start.setTimeZone(timeZone1);		assertEquals(timeZone1, start.getTimeZone());		final DateTimeTimezone end = event.getEnd();		final Date date3 = DateUtils.makeDate(2013, 11, 29);		end.setDate(date3);		assertEquals(date3, end.getDate());		final Date date4 = DateUtils.makeDate(2013, 11, 30);		end.setDateTime(date4);		assertEquals(date4, end.getDateTime());		final TimeZone timeZone2 = TimeZone.getTimeZone("MST");		end.setTimeZone(timeZone2);		assertEquals(timeZone2, end.getTimeZone());		final ArrayList<String> list = new ArrayList<String>();		list.add("RRULE:FREQ=MONTHLY;INTERVAL=1");		list.add("RRULE:FREQ=MONTHLY;INTERVAL=3");		event.setRecurrence(list);		assertNotNull(event.getRecurrence());		assertEquals(2, event.getRecurrence().size());		mapper.writeValue(newFile, event);		assertEquals(loadJsonResourceToString("post_non_null_values_2_event"), normalizeJsonObjectLineFeeds(loadFileToString(newFile)));	}}


### PR DESCRIPTION
Details:
Added encoding funtion - encodeUTF8 - to AbstractGoogleApiTest as a common method to URL encode per unit test. This will resolve the build running on Windows due to the windows-1252 vs UTF-8 issue. 

Added a normalisation method to ensure all line feeds are the same when comparing files between linux builds and windows builds