### PR TITLE
#99 Add new WEBSITE UrlType for Google+ API

### DIFF
--- a/spring-social-google/src/main/java/org/springframework/social/google/api/plus/Person.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/plus/Person.java
@@ -72,6 +72,8 @@ public class Person extends ApiEntity {
 	@JsonProperty("isPlusUser")
 	private boolean plusUser;
 
+	private int circledByCount;
+
 	@JsonProperty
 	private Image image;
 
@@ -146,6 +148,10 @@ public class Person extends ApiEntity {
 	
 	public boolean isPlusUser() {
 		return plusUser;
+	}
+
+	public int getCircledByCount() {
+		return circledByCount;
 	}
 
 	public String getImageUrl() {

--- a/spring-social-google/src/main/java/org/springframework/social/google/api/plus/UrlType.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/plus/UrlType.java
@@ -15,14 +15,13 @@
  */
 package org.springframework.social.google.api.plus;
 
-import org.springframework.social.google.api.impl.ApiEnumSerializer;
-import org.springframework.social.google.api.plus.impl.UrlTypeDeserializer;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.springframework.social.google.api.impl.ApiEnumSerializer;
+import org.springframework.social.google.api.plus.impl.UrlTypeDeserializer;
 
 @JsonSerialize(using = ApiEnumSerializer.class)
 @JsonDeserialize(using = UrlTypeDeserializer.class)
 public enum UrlType {
-	HOME, WORK, BLOG, PROFILE, OTHER, OTHER_PROFILE, CONTRIBUTOR
+    OTHER, OTHER_PROFILE, CONTRIBUTOR, WEBSITE
 }

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/plus/PlusTemplateTest.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/plus/PlusTemplateTest.java
@@ -291,7 +291,7 @@ public class PlusTemplateTest extends AbstractGoogleApiTest {
 				UrlType.OTHER_PROFILE), new ProfileUrl(
 				"https://github.com/GabiAxel/spring-social-google",
 				"Spring Social Google", UrlType.CONTRIBUTOR), new ProfileUrl(
-				"http://www.gabiaxel.com", "Blog", UrlType.OTHER),
+				"http://www.gabiaxel.com", "Blog", UrlType.WEBSITE),
 				new ProfileUrl("https://www.docollab.com",
 						"Docollab - Your Scientific Knowledgebase",
 						UrlType.OTHER));

--- a/spring-social-google/src/test/java/org/springframework/social/google/api/plus/PlusTemplateTest.java
+++ b/spring-social-google/src/test/java/org/springframework/social/google/api/plus/PlusTemplateTest.java
@@ -308,5 +308,6 @@ public class PlusTemplateTest extends AbstractGoogleApiTest {
 		assertEquals("guznik@gmail.com", person.getAccountEmail());
 		assertEquals("https://plus.google.com/+GabrielAxel", person.getUrl());
 		assertTrue(person.isPlusUser());
+		assertEquals(51, person.getCircledByCount());
 	}
 }

--- a/spring-social-google/src/test/resources/org/springframework/social/google/api/plus/person.json
+++ b/spring-social-google/src/test/resources/org/springframework/social/google/api/plus/person.json
@@ -80,7 +80,7 @@
       "label": "Spring Social Google"
     }, 
     {
-      "type": "other", 
+      "type": "website",
       "value": "http://www.gabiaxel.com", 
       "label": "Blog"
     }, 


### PR DESCRIPTION
Fixes https://github.com/GabiAxel/spring-social-google/issues/99 issue.

- Added new WEBSITE UrlType enum
- Removed old UrlType values (according to [https://developers.google.com/+/web/api/rest/latest/people#url](https://developers.google.com/+/web/api/rest/latest/people#url))
- Updated tests